### PR TITLE
Add context for viewModelBuilder

### DIFF
--- a/lib/_viewmodel_builder_widget.dart
+++ b/lib/_viewmodel_builder_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 
 import '_viewmodel_builder.dart';
 
@@ -19,7 +19,7 @@ abstract class ViewModelBuilderWidget<T extends ChangeNotifier>
   );
 
   /// A builder that builds the ViewModel for this UI - Required
-  T viewModelBuilder();
+  T viewModelBuilder(BuildContext context);
 
   /// Indicates if the [builder] should be rebuilt when notifyListeners is called
   ///
@@ -56,7 +56,7 @@ abstract class ViewModelBuilderWidget<T extends ChangeNotifier>
     if (reactive) {
       return ViewModelBuilder<T>.reactive(
         builder: builder,
-        viewModelBuilder: viewModelBuilder,
+        viewModelBuilder: () => viewModelBuilder(context),
         staticChild:
             staticChildBuilder != null ? staticChildBuilder(context) : null,
         onModelReady: onViewModelReady,
@@ -66,7 +66,7 @@ abstract class ViewModelBuilderWidget<T extends ChangeNotifier>
     } else {
       return ViewModelBuilder<T>.nonReactive(
         builder: builder,
-        viewModelBuilder: viewModelBuilder,
+        viewModelBuilder: () => viewModelBuilder(context),
         onModelReady: onViewModelReady,
         disposeViewModel: disposeViewModel,
         createNewModelOnInsert: createNewModelOnInsert,


### PR DESCRIPTION
`BuildContext` is needed for `viewModelBuilder` function thus we may call `Provider` or other context needed dependencies here.

Example usage: 
```dart
class BuilderWidgetExampleView extends ViewModelBuilderWidget<HomeViewModel> {

  @override
  bool get reactive => false;

  @override
  bool get createNewModelOnInsert => false;

  @override
  bool get disposeViewModel => true;

  @override
  Widget builder(
    BuildContext context,
    HomeViewModel model,
    Widget child,
  ) {
    return Scaffold(
      body: Center(
        child: Text(model.title),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: () => model.updateTitle(),
      ),
    );
  }

  @override
  HomeViewModel viewModelBuilder(BuildContext context) {
    final dependency = Provider.of<Dependency>(context);
    return HomeViewModel(dependency);
  }
```