### PR TITLE
[stacked] Add const constructors

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1 - 2020-05-05 - Added const constructors
+
+- Added the `const` keyword to the following widget constructors:
+  `ViewModelBuilder.nonReactive`, `ViewModelBuilder.reactive`, and `ViewModelWidget`
+
 ## 1.4.0 - 2020-05-04 - [Breaking] Moved private files into src folder
 
 - Fix imports, import visibility and changed file names.

--- a/packages/stacked/README.md
+++ b/packages/stacked/README.md
@@ -1,4 +1,4 @@
-# Stacked
+# Stacked [![Pub Version](https://img.shields.io/pub/v/stacked)](https://pub.dev/packages/stacked)
 
 An architecture developed and revised by the [FilledStacks](https://www.youtube.com/filledstacks) community. This architecture was initially a version of Mvvm as [described in this video](https://youtu.be/kDEflMYTFlk). Since then Filledstacks app development team has built 6 production applications with various requirements. This experience along with countless requests for improvements and common functionality is what sparked the creation of this architecture package. It aims to provide **common functionalities to make app development easier** as well as code principles to use during development to ensure your code stays maintainable.
 
@@ -309,7 +309,7 @@ Sometimes you want a widget to have access to the ViewModel but you don't want i
 
 ```dart
 class UpdateTitleButton extends ViewModelWidget<HomeViewModel> {
-  UpdateTitleButton({
+  const UpdateTitleButton({
     Key key,
   }) : super(key: key, reactive: false);
 

--- a/packages/stacked/example/lib/ui/home/home_view_traditional.dart
+++ b/packages/stacked/example/lib/ui/home/home_view_traditional.dart
@@ -23,7 +23,7 @@ class HomeViewTraditional extends StatelessWidget {
 }
 
 class UpdateTitleButton extends ViewModelWidget<HomeViewModel> {
-  UpdateTitleButton({
+  const UpdateTitleButton({
     Key key,
   }) : super(key: key, reactive: false);
 

--- a/packages/stacked/lib/src/view_model_builder.dart
+++ b/packages/stacked/lib/src/view_model_builder.dart
@@ -38,7 +38,7 @@ class ViewModelBuilder<T extends ChangeNotifier> extends StatefulWidget {
   /// Constructs a viewmodel provider that will not rebuild the provided widget when notifyListeners is called.
   ///
   /// Widget from [builder] will be used as a staic child and won't rebuild when notifyListeners is called
-  ViewModelBuilder.nonReactive({
+  const ViewModelBuilder.nonReactive({
     @required this.builder,
     @required this.viewModelBuilder,
     this.onModelReady,
@@ -48,7 +48,7 @@ class ViewModelBuilder<T extends ChangeNotifier> extends StatefulWidget {
         staticChild = null;
 
   /// Constructs a viewmodel provider that fires the [builder] function when notifyListeners is called in the viewmodel.
-  ViewModelBuilder.reactive({
+  const ViewModelBuilder.reactive({
     @required this.builder,
     @required this.viewModelBuilder,
     this.staticChild,

--- a/packages/stacked/lib/src/view_model_widget.dart
+++ b/packages/stacked/lib/src/view_model_widget.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 abstract class ViewModelWidget<T> extends Widget {
   final bool reactive;
 
-  ViewModelWidget({Key key, this.reactive = true}) : super(key: key);
+  const ViewModelWidget({Key key, this.reactive = true}) : super(key: key);
 
   @protected
   Widget build(BuildContext context, T viewModel);

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked
 description: An architecture and widgets for an MVVM inspired architecture in Flutter. It provides common functionalities required to build a large application in a understandable manner.
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/FilledStacks/stacked
 
 environment:


### PR DESCRIPTION
Resolves #25.

### Miscellaneous

I added a https://shields.io badge for the Pub version in order to be able to see the currently uploaded Pub version from the GitHub repo and also because it allows to go to the Pub package page with a single click. This way you can easily navigate from Pub to GitHub (using the "Repository (GitHub)" button) and now also the other way around.  
Remove it if you think it should not be included.

Sidenote: I was wondering why the changelog uses headers to show changes. I followed it now because I am fine with doing so. However, I find it a bit hard to read the changelog when the text is so big that it spans across the entire screen.  
I like the [way the Flutter team does it](https://github.com/flutter/plugins/blob/master/packages/url_launcher/url_launcher/CHANGELOG.md). This has nothing to do with the PR; though, was just wondering 😅 