### PR TITLE
Error with unit test

### DIFF
--- a/packages/stacked/lib/src/base_view_models.dart
+++ b/packages/stacked/lib/src/base_view_models.dart
@@ -32,7 +32,7 @@ class BaseViewModel extends ChangeNotifier {
     _setBusyForModelOrObject(true, busyObject: busyObject);
     var value = await busyFuture.catchError((error) {
       // TODO: Should probably store the error here and indicate we have an error
-      return null;
+      throw error;
     });
     _setBusyForModelOrObject(false, busyObject: busyObject);
     return value;

--- a/packages/stacked/test/baseviewmodel_test.dart
+++ b/packages/stacked/test/baseviewmodel_test.dart
@@ -11,9 +11,9 @@ class TestViewModel extends BaseViewModel {
 
   Future _futureToRun(bool fail) async {
     await Future.delayed(Duration(milliseconds: 50));
-    if (fail) {
-      throw Exception('Broken Future');
-    }
+    // if (fail) {
+    //   throw Exception('Broken Future');
+    // }
   }
 }
 


### PR DESCRIPTION
1. Throw error when there is an issue with the execution of future rathe…r than returning null
2. Updated the unit test so that the test view model  does not have to throw error as the basemodel itself throws the error



@FilledStacks For me unit tests are failing for future test `When a future fails it should indicate there\'s an error and no data` as the `runBusyFuture` is return `null` for the said error condition. 