### PR TITLE
Make the showCustomSnackBar callable inside initiState like showSnackbar.

### DIFF
--- a/packages/stacked_services/lib/src/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar_service.dart
@@ -43,6 +43,8 @@ class SnackbarService {
       Widget titleText,
       Widget messageText,
       Widget icon,
+      /// with instantInit = false you can put Get.snackbar on initState
+      bool instantInit = false,
       bool shouldIconPulse = true,
       double maxWidth,
       EdgeInsets margin = const EdgeInsets.all(0.0),
@@ -73,7 +75,7 @@ class SnackbarService {
       double overlayBlur = 0.0,
       Color overlayColor = Colors.transparent,
       Form userInputForm}) {
-    return GetBar(
+    final getBar = GetBar(
             key: key,
             title: title,
             message: message,
@@ -109,7 +111,17 @@ class SnackbarService {
             barBlur: barBlur,
             overlayBlur: overlayBlur,
             overlayColor: overlayColor,
-            userInputForm: userInputForm)
-        .show();
+            userInputForm: userInputForm);
+
+    if (instantInit) {
+      return getBar.show();
+    } else {
+      Completer completer = new Completer();
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        final result = await getBar.show();
+        completer.complete(result);
+      });
+      return completer.future;
+    }
   }
 }


### PR DESCRIPTION
This will prevent this common exception: 
```
Unhandled exception: setState() or markNeedsBuild() called during build.
```

The original implementation use the same technique:

https://github.com/jonataslaw/get/blob/5ccbb96da82669472847aaf071b00e47a0bb641c/lib/src/get_main.dart#L481

https://github.com/jonataslaw/get/blob/5ccbb96da82669472847aaf071b00e47a0bb641c/lib/src/get_main.dart#L563-L570