### PR TITLE
Update HookViewModelWidget constructor to const

### DIFF
--- a/packages/stacked_hooks/lib/src/_hooks_viewmodel_widget.dart
+++ b/packages/stacked_hooks/lib/src/_hooks_viewmodel_widget.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 /// An implementation of the ViewModelWidget that allows you to use Hooks in the build
 abstract class HookViewModelWidget<T> extends HookWidget {
   final bool reactive;
-  HookViewModelWidget({Key key, this.reactive = true});
+  const HookViewModelWidget({Key key, this.reactive = true});
 
   @override
   Widget build(BuildContext context) =>


### PR DESCRIPTION
Per the associated video (Stacked deep dive part 2) at 5:39.