### PR TITLE
Expose barrierDismissible for confirmationDialog

### DIFF
--- a/packages/stacked_services/example/lib/ui/views/home_screen.dart
+++ b/packages/stacked_services/example/lib/ui/views/home_screen.dart
@@ -92,7 +92,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 await _dialogService.showConfirmationDialog(
                   title: 'Test Confirmation Dialog Title',
                   description: 'Test Confirmation Dialog Description',
-                  barrierDismissible = true,
+                  barrierDismissible: true,
                 );
               },
               child: Text(
@@ -131,7 +131,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   dialogPlatform: DialogPlatform.Cupertino,
                   title: 'Test Confirmation Dialog Title',
                   description: 'Test Confirmation Dialog Description',
-                  barrierDismissible = true,
+                  barrierDismissible: true,
                 );
               },
               child: Text(

--- a/packages/stacked_services/example/lib/ui/views/home_screen.dart
+++ b/packages/stacked_services/example/lib/ui/views/home_screen.dart
@@ -92,6 +92,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 await _dialogService.showConfirmationDialog(
                   title: 'Test Confirmation Dialog Title',
                   description: 'Test Confirmation Dialog Description',
+                  barrierDismissible = true,
                 );
               },
               child: Text(
@@ -130,6 +131,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   dialogPlatform: DialogPlatform.Cupertino,
                   title: 'Test Confirmation Dialog Title',
                   description: 'Test Confirmation Dialog Description',
+                  barrierDismissible = true,
                 );
               },
               child: Text(

--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -186,7 +186,8 @@ class DialogService {
     String description,
     String cancelTitle = 'Cancel',
     String confirmationTitle = 'Ok',
-
+    bool barrierDismissible = false,
+    
     /// Indicates which [DialogPlatform] to show.
     ///
     /// When not set a Platform specific dialog will be shown
@@ -198,6 +199,7 @@ class DialogService {
         buttonTitle: confirmationTitle,
         cancelTitle: cancelTitle,
         dialogPlatform: dialogPlatform,
+        barrierDismissible: barrierDismissible,
       );
 
   /// Completes the dialog and passes the [response] to the caller


### PR DESCRIPTION
Added the parameter barrierDismissible  for exposure in the confirmationDialog and adjusted the example to use the new functionality directly.