### PR TITLE
Fixed routes to breaking changes in auto_routes package

### DIFF
--- a/packages/stacked_services/example/lib/app/routes.dart
+++ b/packages/stacked_services/example/lib/app/routes.dart
@@ -7,12 +7,22 @@ import '../ui/views/second_screen.dart';
 
 // Defining routes and global transitions
 @CustomAutoRouter(
-    transitionsBuilder: TransitionsBuilders.zoomIn, durationInMilliseconds: 400)
-class $Router {
-  @initial
-  HomeScreen homeScreenRoute;
-
-  FirstScreen firstScreenRoute;
-
-  SecondScreen secondScreenRoute;
-}
+    routes: <AutoRoute>[
+    MaterialRoute(
+      page: HomeScreen,
+      name: 'homeScreenRoute',
+      initial: true,
+    ),
+    MaterialRoute(
+      page: FirstScreen,
+      name: 'firstScreenRoute',
+    ),
+    MaterialRoute(
+      page: SecondScreen,
+      name: 'secondScreenRoute',
+    ),
+  ],
+  transitionsBuilder: TransitionsBuilders.zoomIn, 
+  durationInMilliseconds: 400,
+)
+class $Router {}

--- a/packages/stacked_services/example/lib/app/routes.dart
+++ b/packages/stacked_services/example/lib/app/routes.dart
@@ -7,7 +7,7 @@ import '../ui/views/second_screen.dart';
 
 // Defining routes and global transitions
 @CustomAutoRouter(
-    routes: <AutoRoute>[
+  routes: <AutoRoute>[
     MaterialRoute(
       page: HomeScreen,
       name: 'homeScreenRoute',

--- a/packages/stacked_services/example/lib/app/routes.gr.dart
+++ b/packages/stacked_services/example/lib/app/routes.gr.dart
@@ -4,18 +4,20 @@
 // AutoRouteGenerator
 // **************************************************************************
 
-import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:auto_route/auto_route.dart';
-import 'package:example/ui/views/home_screen.dart';
-import 'package:example/ui/views/first_screen.dart';
-import 'package:example/ui/views/second_screen.dart';
+// ignore_for_file: public_member_api_docs
 
-abstract class Routes {
-  static const homeScreenRoute = '/';
-  static const firstScreenRoute = '/first-screen-route';
-  static const secondScreenRoute = '/second-screen-route';
-  static const all = {
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+import '../ui/views/first_screen.dart';
+import '../ui/views/home_screen.dart';
+import '../ui/views/second_screen.dart';
+
+class Routes {
+  static const String homeScreenRoute = '/';
+  static const String firstScreenRoute = '/first-screen';
+  static const String secondScreenRoute = '/second-screen';
+  static const all = <String>{
     homeScreenRoute,
     firstScreenRoute,
     secondScreenRoute,
@@ -24,78 +26,45 @@ abstract class Routes {
 
 class Router extends RouterBase {
   @override
-  Set<String> get allRoutes => Routes.all;
-
-  @Deprecated('call ExtendedNavigator.ofRouter<Router>() directly')
-  static ExtendedNavigatorState get navigator =>
-      ExtendedNavigator.ofRouter<Router>();
-
+  List<RouteDef> get routes => _routes;
+  final _routes = <RouteDef>[
+    RouteDef(Routes.homeScreenRoute, page: HomeScreen),
+    RouteDef(Routes.firstScreenRoute, page: FirstScreen),
+    RouteDef(Routes.secondScreenRoute, page: SecondScreen),
+  ];
   @override
-  Route<dynamic> onGenerateRoute(RouteSettings settings) {
-    final args = settings.arguments;
-    switch (settings.name) {
-      case Routes.homeScreenRoute:
-        if (hasInvalidArgs<HomeScreenArguments>(args)) {
-          return misTypedArgsRoute<HomeScreenArguments>(args);
-        }
-        final typedArgs = args as HomeScreenArguments ?? HomeScreenArguments();
-        return PageRouteBuilder<dynamic>(
-          pageBuilder: (context, animation, secondaryAnimation) =>
-              HomeScreen(key: typedArgs.key),
-          settings: settings,
-          transitionsBuilder: TransitionsBuilders.zoomIn,
-          transitionDuration: const Duration(milliseconds: 400),
-        );
-      case Routes.firstScreenRoute:
-        if (hasInvalidArgs<FirstScreenArguments>(args)) {
-          return misTypedArgsRoute<FirstScreenArguments>(args);
-        }
-        final typedArgs =
-            args as FirstScreenArguments ?? FirstScreenArguments();
-        return PageRouteBuilder<dynamic>(
-          pageBuilder: (context, animation, secondaryAnimation) =>
-              FirstScreen(key: typedArgs.key),
-          settings: settings,
-          transitionsBuilder: TransitionsBuilders.zoomIn,
-          transitionDuration: const Duration(milliseconds: 400),
-        );
-      case Routes.secondScreenRoute:
-        if (hasInvalidArgs<SecondScreenArguments>(args)) {
-          return misTypedArgsRoute<SecondScreenArguments>(args);
-        }
-        final typedArgs =
-            args as SecondScreenArguments ?? SecondScreenArguments();
-        return PageRouteBuilder<dynamic>(
-          pageBuilder: (context, animation, secondaryAnimation) =>
-              SecondScreen(key: typedArgs.key),
-          settings: settings,
-          transitionsBuilder: TransitionsBuilders.zoomIn,
-          transitionDuration: const Duration(milliseconds: 400),
-        );
-      default:
-        return unknownRoutePage(settings.name);
-    }
-  }
+  Map<Type, AutoRouteFactory> get pagesMap => _pagesMap;
+  final _pagesMap = <Type, AutoRouteFactory>{
+    HomeScreen: (data) {
+      var args = data.getArgs<HomeScreenArguments>(
+        orElse: () => HomeScreenArguments(),
+      );
+      return MaterialPageRoute<dynamic>(
+        builder: (context) => HomeScreen(key: args.key),
+        settings: data,
+      );
+    },
+    FirstScreen: (data) {
+      return MaterialPageRoute<dynamic>(
+        builder: (context) => const FirstScreen(),
+        settings: data,
+      );
+    },
+    SecondScreen: (data) {
+      return MaterialPageRoute<dynamic>(
+        builder: (context) => const SecondScreen(),
+        settings: data,
+      );
+    },
+  };
 }
 
-// *************************************************************************
-// Arguments holder classes
-// **************************************************************************
+/// ************************************************************************
+/// Arguments holder classes
+/// *************************************************************************
 
-//HomeScreen arguments holder class
+/// HomeScreen arguments holder class
 class HomeScreenArguments {
   final Key key;
   HomeScreenArguments({this.key});
-}
-
-//FirstScreen arguments holder class
-class FirstScreenArguments {
-  final Key key;
-  FirstScreenArguments({this.key});
-}
-
-//SecondScreen arguments holder class
-class SecondScreenArguments {
-  final Key key;
-  SecondScreenArguments({this.key});
 }


### PR DESCRIPTION
Since version 0.6.0 the auto_route package requires a list instead of class fields for routes declaration.
See: [https://stackoverflow.com/questions/62853598/flutter-auto-route-generator-not-building-formatexception-not-an-instance-of-l](https://stackoverflow.com/questions/62853598/flutter-auto-route-generator-not-building-formatexception-not-an-instance-of-l)

Not sure if the newly generated routes.gr.dart file needs to be included or not. 