### PR TITLE
Change the way how we register an Custom Dialog and Snackbar

### DIFF
--- a/packages/stacked_services/README.md
+++ b/packages/stacked_services/README.md
@@ -70,15 +70,25 @@ await _dialogService.showDialog(
 
 ### Custom Dialog UI
 
-In addition to platform-specific UI, you can also build a custom dialog. To do that we'll do the following. In your UI folder or shared folder under UI, if you have one, create a new file called `setup_dialog_ui.dart`. Inside you will create a new function called `setupDialogUi`. In there you will call the function `registerCustomDialogUi` on the `DialogService`. _Look at the `setup_dialog_ui` file for a full example_
+In addition to platform-specific UI, you can also build a custom dialog. To do that we'll do the following. Start by creating an enum called `DialogType`.
+
+```dart
+/// The type of dialog to show
+enum DialogType { base, form }
+```
+
+In your UI folder or shared folder under UI, if you have one, create a new file called `setup_dialog_ui.dart`. Inside you will create a new function called `setupDialogUi`. In there you will call the function `registerCustomDialogBuilder` on the `DialogService`. _Look at the `setup_dialog_ui` file for a full example_
 
 ```dart
 void setupDialogUi() {
   var dialogService = locator<DialogService>();
 
-  dialogService.registerCustomDialogUi((context, dialogRequest) => Dialog(
-    child: // Build your UI here //
-  ));
+  dialogService.registerCustomDialogBuilder(
+    variant: DialogType.base,
+    builder: (BuildContext context, DialogRequest dialogRequest) => Dialog(
+      child: // Build your UI here //
+    ),
+  );
 }
 ```
 
@@ -120,6 +130,9 @@ final bool takesInput;
 
 /// Intended to be used with enums. If you want to create multiple different
 /// dialogs. Pass your enum in here and check the value in the builder
+final dynamic variant;
+
+/// Extra data to be passed to the UI
 final dynamic customData;
 ```
 
@@ -139,6 +152,7 @@ Now in your ViewModels, you can make use of the dialog as follows.
 
 ```dart
 await _dialogService.showCustomDialog(
+  variant: DialogType.base,
   title: 'This is a custom UI with Text as main button',
   description: 'Sheck out the builder in the dialog_ui_register.dart file',
   mainButtonTitle: 'Ok',
@@ -150,8 +164,9 @@ await _dialogService.showCustomDialog(
 The custom dialog follows the same rules as the normal dialog. Calling `completeDialog` and passing in a `DialogResponse` object will return it to the caller that's awaiting on the dialog response UI. So when you have a tap handler in your dialog and you want to close the dialog, use the `completeDialog` function.
 
 ```dart
-dialogService.registerCustomDialogUi(
-  (context, dialogRequest) => Dialog(
+dialogService.registerCustomDialogBuilder(
+  variant: DialogType.form,
+  builder: (BuildContext context, DialogRequest dialogRequest) => Dialog(
     child: Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
@@ -206,6 +221,7 @@ Where you called your dialog function and awaited you'll receive the data return
 
 ```dart
 var response = await _dialogService.showCustomDialog(
+  variant: DialogType.form,
   title: 'My custom dialog',
   description: 'This is my dialog description',
   mainButtonTitle: 'Confirm',
@@ -306,8 +322,8 @@ Then open up the `setup_snackbar_ui.dart` created above and we'll add the config
 void setupSnackbarUi() {
   final service = locator<SnackbarService>();
 
-  service.registerCustomSnackbarconfig(
-    customData: SnackbarType.blueAndYellow,
+  service.registerCustomSnackbarConfig(
+    variant: SnackbarType.blueAndYellow,
     config: SnackbarConfig(
       backgroundColor: Colors.blueAccent,
       textColor: Colors.yellow,
@@ -316,8 +332,8 @@ void setupSnackbarUi() {
     ),
   );
 
-  service.registerCustomSnackbarconfig(
-    customData: SnackbarType.greenAndRed,
+  service.registerCustomSnackbarConfig(
+    variant: SnackbarType.greenAndRed,
     config: SnackbarConfig(
       backgroundColor: Colors.white,
       titleColor: Colors.green,
@@ -328,11 +344,11 @@ void setupSnackbarUi() {
 }
 ```
 
-Now you can call `showCustomSnackBar` and pass in the `customData` enum that you'd like to use. The following code will show the blueAndYellow snackbar.
+Now you can call `showCustomSnackBar` and pass in the `variant` enum that you'd like to use. The following code will show the blueAndYellow snackbar.
 
 ```dart
 _snackbarService.showCustomSnackBar(
-  customData: SnackbarType.blueAndYellow,
+  variant: SnackbarType.blueAndYellow,
   message: 'Blue and yellow',
   title: 'The message is the message',
   duration: Duration(seconds: 2),
@@ -348,10 +364,9 @@ And the following code will show the greenAndRed snackbar
 
 ```dart
 _snackbarService.showCustomSnackBar(
-  customData: SnackbarType.greenAndRed,
+  variant: SnackbarType.greenAndRed,
   title: 'Green and Red',
-  message:
-      'The text is green and red and the background is white',
+  message: 'The text is green and red and the background is white',
   duration: Duration(seconds: 2),
   onTap: (_) {
     print('snackbar tapped');

--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -19,14 +19,18 @@ class DialogService {
       _customDialogBuilders =
       Map<dynamic, Widget Function(BuildContext, DialogRequest)>();
 
-  @Deprecated('Prefer to use the _customDialogBuilders property')
+  @Deprecated(
+    'Prefer to use the _customDialogBuilders property. Will be removed in future release',
+  )
   Widget Function(BuildContext, DialogRequest) _customDialogUI;
 
   get navigatorKey {
     return Get.key;
   }
 
-  @Deprecated('Prefer to use the registerCustomDialogBuilder() method')
+  @Deprecated(
+    'Prefer to use the registerCustomDialogBuilder() method. Will be removed in future release',
+  )
   void registerCustomDialogUi(
     Widget Function(BuildContext, DialogRequest) dialogBuilder,
   ) {

--- a/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
@@ -22,11 +22,23 @@ class SnackbarService {
       _snackbarConfig = config;
 
   /// Saves the [config] against the value of [customData]
+  @Deprecated(
+      'Prefer to use the registerCustomSnackbarConfig() method. Will be removed in future release')
   void registerCustomSnackbarconfig({
     @required dynamic customData,
     @required SnackbarConfig config,
   }) =>
-      _customSnackbarConfigs[customData] = config;
+      registerCustomSnackbarConfig(
+        variant: customData,
+        config: config,
+      );
+
+  /// Saves the [config] against the value of [variant]
+  void registerCustomSnackbarConfig({
+    @required dynamic variant,
+    @required SnackbarConfig config,
+  }) =>
+      _customSnackbarConfigs[variant] = config;
 
   /// Shows a snack bar with the details passed in
   void showSnackbar({
@@ -80,17 +92,27 @@ class SnackbarService {
 
   Future showCustomSnackBar({
     @required String message,
-    @required dynamic customData,
+    @deprecated dynamic customData,
+    dynamic variant,
     String title,
     String mainButtonTitle,
     Function onMainButtonTapped,
     Function onTap,
     Duration duration = const Duration(seconds: 1),
   }) {
-    var snackbarConfig = _customSnackbarConfigs[customData];
+    // TODO: Remove customData in the future release and set variant as required
+    final snakcbarVariant = variant ?? customData;
+    assert(
+      snakcbarVariant != null,
+      'No variant defined, you should provide the variant property to show a custom snackbar',
+    );
+
+    var snackbarConfig = _customSnackbarConfigs[snakcbarVariant];
+
     if (snackbarConfig == null) {
       throw CustomSnackbarException(
-          'No config found for $customData make sure you have called registerCustomConfig. See [README LINK HERE] for implementation details.');
+        'No config found for $snakcbarVariant make sure you have called registerCustomConfig. See [README LINK HERE] for implementation details.',
+      );
     }
 
     final mainButtonWidget = _getMainButtonWidget(
@@ -103,20 +125,22 @@ class SnackbarService {
       titleText: Text(
         title,
         style: TextStyle(
-            color: snackbarConfig?.titleColor ??
-                snackbarConfig?.textColor ??
-                Colors.white,
-            fontWeight: FontWeight.w800,
-            fontSize: 16),
+          color: snackbarConfig?.titleColor ??
+              snackbarConfig?.textColor ??
+              Colors.white,
+          fontWeight: FontWeight.w800,
+          fontSize: 16,
+        ),
       ),
       messageText: Text(
         message,
         style: TextStyle(
-            color: snackbarConfig?.messageColor ??
-                snackbarConfig?.textColor ??
-                Colors.white,
-            fontWeight: FontWeight.w300,
-            fontSize: 14),
+          color: snackbarConfig?.messageColor ??
+              snackbarConfig?.textColor ??
+              Colors.white,
+          fontWeight: FontWeight.w300,
+          fontSize: 14,
+        ),
       ),
       icon: snackbarConfig.icon,
       shouldIconPulse: snackbarConfig.shouldIconPulse,
@@ -169,17 +193,19 @@ class SnackbarService {
     Function onMainButtonTapped,
     SnackbarConfig config,
   }) {
-    return mainButtonTitle != null
-        ? FlatButton(
-            child: Text(
-              mainButtonTitle,
-              style: TextStyle(
-                  color: config?.mainButtonTextColor ??
-                      config?.textColor ??
-                      Colors.white),
-            ),
-            onPressed: onMainButtonTapped,
-          )
-        : null;
+    if (mainButtonTitle == null) {
+      return null;
+    }
+
+    return FlatButton(
+      child: Text(
+        mainButtonTitle,
+        style: TextStyle(
+          color:
+              config?.mainButtonTextColor ?? config?.textColor ?? Colors.white,
+        ),
+      ),
+      onPressed: onMainButtonTapped,
+    );
   }
 }


### PR DESCRIPTION
## Custom Dialog

- [x] Add ability, like Custom Snackbar, to registry multiple variants of dialog.
- [x] Use variant term instead `customData`, I thins this is more clear then `customData` term to refer a specific type of Dialog
- [x] Add a builder property to declare the UI.
- [x] Rename `registerCustomDialogUi` to `registerCustomDialogBuilder`.
- [x] Update documentation.

## Custom Snackbar

- [x] Use variant term instead `customData`, like I said for Custom Dialog, I think this is more clear use the `variant` term instead `customData` to refer a specific.
- [x] Normalize the name, instead `registerCustomSnackbarconfig` use the `registerCustomSnackbarConfig`.
- [x] Update documentation.

This PR, close #113 