### PR TITLE
Add types to navigatorKey and nestedNavigationKey

### DIFF
--- a/packages/stacked_services/lib/src/navigation_service.dart
+++ b/packages/stacked_services/lib/src/navigation_service.dart
@@ -27,12 +27,10 @@ class NavigationService {
     NavigationTransition.LeftToRighttWithFade: Transition.leftToRightWithFade,
   };
 
-  get navigatorKey {
-    return Get.key;
-  }
+  GlobalKey<NavigatorState> get navigatorKey => Get.key;
 
   /// Creates and/or returns a new navigator key based on the index passed in
-  nestedNavigationKey(int index) => Get.nestedKey(index);
+  GlobalKey<NavigatorState> nestedNavigationKey(int index) => Get.nestedKey(index);
 
   /// Allows you to configure the default behaviour for navigation.
   ///


### PR DESCRIPTION
When configuring the `dart`'s analyzer with stricter static checks:

```yaml
analyzer:
  strong-mode:
    implicit-casts: false
```

Passing the `NavigationService`'s `navigationKey` to the MaterialApp widget:

```dart
MaterialApp(
  ...
  navigatorKey: NavigationService().navigatorKey,
);
```

Generates an error:
```
error: The argument type 'dynamic' can't be assigned to the parameter type 'GlobalKey<NavigatorState>'. (argument_type_not_assignable)
```

Fixed by explicitly defining the types of `navigatorKey` and `nestedNavigationKey`.