### PR TITLE
YAML for localisation files

### DIFF
--- a/packages/stacked_localisation/stacked_localisation/README.md
+++ b/packages/stacked_localisation/stacked_localisation/README.md
@@ -8,7 +8,7 @@ The localisation package is very simple. It provides you with a service from whi
 
 ## Setup
 
-To use the localisation service there's a few things that has to be done. We start off by adding the stacked_localisation and the stacked_localisation_generator package.
+To use the localisation service there's a few things that has to be done. We start off by adding the stacked_localisation and the stacked_localisation_generator package (and build_runner if you don't already have it).
 
 ```yaml
 dependencies:
@@ -17,6 +17,7 @@ dependencies:
 
 dev_dependencies:
   ...
+  build_runner:
   stacked_localisation_generator:
 ```
 
@@ -27,7 +28,7 @@ assets:
   - assets/lang/
 ```
 
-Then we you will create the folders mentioned above and place your strings for a different language in there. Create a folder called assets in the root folder and inside that folder create a new folder called lang. Then create a new file inside it called en.json and place the following json in there.
+Then we will create the folders mentioned above and place your strings for a different language in there. Create a folder called assets in the root folder and inside that folder create a new folder called lang. Then create a new file inside it called en.json or en.yaml and place the following JSON in there.
 
 ```json
 {
@@ -36,6 +37,14 @@ Then we you will create the folders mentioned above and place your strings for a
     "subtitle": "I live in this Home"
   }
 }
+```
+
+or for YAML
+
+```yaml
+HomeView:
+  title: This is my Home
+  subtitle: I live in this Home
 ```
 
 Then run `flutter pub run build_runner build --delete-conflicting-outputs` to generate the localisation_string_keys.dart file. This file will look like this.

--- a/packages/stacked_localisation/stacked_localisation_generator/README.md
+++ b/packages/stacked_localisation/stacked_localisation_generator/README.md
@@ -4,15 +4,16 @@ A code generator that generates all the keys in a language file to be used with 
 
 ## Setup
 
-This package should be added as a dev dependency in the project you're using.
+This package (and build_runner if you don't already have it) should be added as a dev dependency in the project you're using.
 
 ```yaml
 dev_dependencies:
   ...
+  build_runner:
   stacked_localisation_generator:
 ```
 
-Then create a new folder in root called assets with another folder inside it called lang. This folder will contain the language json files. Here's an example of a file called en.json
+Then create a new folder in root called assets with another folder inside it called lang. This folder will contain the language json or yaml files. Here's an example of a file called en.json
 
 ```json
 {
@@ -23,7 +24,15 @@ Then create a new folder in root called assets with another folder inside it cal
 }
 ```
 
-When you run `flutter pub run build_runner build --delete-conflicting-outputs` the package will generate a new file called `localisation_string_keys.dart` that can be found at the root of the lib folder that contains type save keys for the language string definition above. The json above will produce the following keys.
+or for en.yaml
+
+```yaml
+HomeView:
+  title: This is my Home
+  subtitle: I live in this Home
+```
+
+When you run `flutter pub run build_runner build --delete-conflicting-outputs` the package will generate a new file called `localisation_string_keys.dart` that can be found at the root of the lib folder that contains type save keys for the language string definition above. The above will produce the following keys.
 
 ```dart
 /// This code is generated. DO NOT edit by hand
@@ -35,3 +44,11 @@ class HomeViewStrings {
 ```
 
 This can be accessed statically throughout the application where the keys are required. To see a full example of using stacked_localisaion you can check out the walkthrough [here](https://github.com/FilledStacks/stacked/tree/master/packages/stacked_localisation/stacked_localisation).
+
+## Contributing
+
+To run all generator tests:
+
+```sh
+flutter pub run build_runner test
+```

--- a/packages/stacked_localisation/stacked_localisation_generator/lib/src/localisation_string_key_generator.dart
+++ b/packages/stacked_localisation/stacked_localisation_generator/lib/src/localisation_string_key_generator.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:path/path.dart' as p;
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
+import 'package:yaml/yaml.dart';
 
 import 'map_utils.dart';
 
@@ -22,8 +23,8 @@ class LocalisationStringKeyGenerator implements Builder {
     await for (final input in buildStep.findAssets(_allLanguageFiles)) {
       var fileContent = await buildStep.readAsString(input);
 
-      var languageStringsMap =
-          json.decode(fileContent) as Map<dynamic, dynamic>;
+      var languageStringsMap = loadYaml(fileContent) as Map<dynamic, dynamic>;
+
       var localisationstrings = getStringKeysCodeFromMap(languageStringsMap);
 
       // Bail out after the first file. We only need 1 language file to define all the keys since

--- a/packages/stacked_localisation/stacked_localisation_generator/pubspec.lock
+++ b/packages/stacked_localisation/stacked_localisation_generator/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.2.0"
+  build_test:
+    dependency: "direct dev"
+    description:
+      name: build_test
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   built_collection:
     dependency: transitive
     description:
@@ -492,7 +499,7 @@ packages:
     source: hosted
     version: "0.7.3"
   yaml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: yaml
       url: "https://pub.dartlang.org"

--- a/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
+++ b/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
@@ -13,7 +13,9 @@ dependencies:
   mustache: ^1.1.1
   glob: ^1.2.0
   path: ^1.6.4
+  yaml: ^2.2.1
 
 dev_dependencies:
   test:
   build_runner:
+  build_test:

--- a/packages/stacked_localisation/stacked_localisation_generator/test/localisation_string_key_generator_test.dart
+++ b/packages/stacked_localisation/stacked_localisation_generator/test/localisation_string_key_generator_test.dart
@@ -1,0 +1,55 @@
+import 'package:build_test/build_test.dart';
+import 'package:stacked_localisation_generator/src/localisation_string_key_generator.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LocalisationStringKeyGeneratorTest -', () {
+    group('Assets -', () {
+      test(
+          'When given a JSON file, should generate a class called HomeViewStrings',
+          () async {
+        await testBuilder(LocalisationStringKeyGenerator(), {
+          'a|assets/lang/en.json': r'''
+{
+  "HomeView": {
+    "title": "This is my Home",
+    "subtitle": "I live in this Home"
+  }
+}'''
+        }, outputs: {
+          'a|lib/localisation_string_keys.dart': r'''
+/// This code is generated. DO NOT edit by hand
+
+
+class HomeViewStrings {
+  static String title = 'HomeView.title';
+  static String subtitle = 'HomeView.subtitle';
+}
+'''
+        });
+      });
+
+      test(
+          'When given a YAML file, should generate a class called HomeViewStrings',
+          () async {
+        await testBuilder(LocalisationStringKeyGenerator(), {
+          'a|assets/lang/en.yaml': r'''
+HomeView:
+  title: This is my Home
+  subtitle: I live in this Home
+'''
+        }, outputs: {
+          'a|lib/localisation_string_keys.dart': r'''
+/// This code is generated. DO NOT edit by hand
+
+
+class HomeViewStrings {
+  static String title = 'HomeView.title';
+  static String subtitle = 'HomeView.subtitle';
+}
+'''
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
I'd prefer to have localization files as YAML, mainly to have the original language as comments. Ex:

```yaml
# Español

HomeView:
  title: Esta es mi casa # This is my Home
  subtitle: Vivo en esta casa # I live in this Home
```

This PR changes from `dart:convert:json.decode()` to `yaml.loadYaml()`. And since JSON is a subset of YAML, This is not a breaking change. The JSON decodes the same as before.

I updated documentation and added tests for the runner for both JSON and YAML. From now on you will need to run `flutter pub run build_runner test` to test this package. However, there is a bug when running tests::

```
Running tests...

Precompiling executable...
Precompiled test:test.
00:00 +0: test\map_utils_test.dart: MapUtilsTest - getStringKeysCodeFromMap - When given an empty map should return generator comment only
00:00 +1: test\localisation_string_key_generator_test.dart: LocalisationStringKeyGeneratorTest - Assets - When given a JSON file, should generate a class called HomeViewStrings
00:00 +2: test\localisation_string_key_generator_test.dart: LocalisationStringKeyGeneratorTest - Assets - When given a JSON file, should generate a class called HomeViewStrings
00:00 +3: test\localisation_string_key_generator_test.dart: LocalisationStringKeyGeneratorTest - Assets - When given a JSON file, should generate a class called HomeViewStrings
00:00 +4: test\localisation_string_key_generator_test.dart: LocalisationStringKeyGeneratorTest - Assets - When given a YAML file, should generate a class called HomeViewStrings
00:00 +5: All tests passed!
```

If I edit any of the MapsUtils tests, they fail as expected, so I believe this is just a display bug in the `build_test` package.