### PR TITLE
Update Get to latest, fixing crash on new Flutter versions on master branch.

### DIFF
--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # navigation
-  get: ^3.8.0
+  get: ^3.17.1 
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Since at least `1.24.0-7.0.pre.69 on master` there has been an error with Get prior to `3.16.1`. 
The issue is described here: [GetX issue 762](https://github.com/jonataslaw/getx/issues/762). 

This pull request updates Get to the latest version `3.17.1` and fixes the crash.