### PR TITLE
Uses unique instance of GetIt locator to avoid conflicts with apps

### DIFF
--- a/packages/stacked_themes/lib/src/locator_setup.dart
+++ b/packages/stacked_themes/lib/src/locator_setup.dart
@@ -2,7 +2,7 @@ import 'package:get_it/get_it.dart';
 import 'package:stacked_themes/src/services/shared_preferences_service.dart';
 import 'package:stacked_themes/src/services/statusbar_service.dart';
 
-final locator = GetIt.instance;
+final locator = GetIt.asNewInstance();
 
 Future setupLocator() async {
   var sharedPreferences = await SharedPreferencesService.getInstance();

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
-version: 0.2.2+2
+version: 0.2.3+2
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 
 environment:
@@ -10,10 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^4.3.2+3
+  provider: ^4.3.3
   rxdart: ^0.25.0
   shared_preferences: ^0.5.12+4
-  get_it: ^5.0.3
+  get_it: ^5.0.6
   flutter_statusbarcolor: ^0.2.3
 
 dev_dependencies:


### PR DESCRIPTION
GetIt supports creating individual instances. When using GetIt inside of a package this is good practice, otherwise conflicts can arise between an app using GetIt and the package.