### PR TITLE
Add support for abstract class types

### DIFF
--- a/packages/stacked/README.md
+++ b/packages/stacked/README.md
@@ -1033,12 +1033,14 @@ _Note_: When your view arguments change you have to run the code generation comm
 
 ### Dependency Registration
 
-The other major piece of boilerplate that was required was setting up get_it and making use of it on its own. This is still a very valid approach but with this new changes I wanted to introduce a quicker way of setting all that up and remove the boilerplate. This is also done using the `StackedApp` annotation. The class takes in a list of `DependencyRegistration`'s into a property called `dependencies`.
+The other major piece of boilerplate that was required was setting up get_it and making use of it on its own. This is still a very valid approach but with these new changes I wanted to introduce a quicker way of setting all that up and remove the boilerplate. This is also done using the `StackedApp` annotation. The class takes in a list of `DependencyRegistration`'s into a property called `dependencies`.
 
 ```dart
 @StackedApp(
 dependencies: [
     LazySingleton(classType: DialogService),
+    // abstracted class type support
+    LazySingleton(classType: FirebaseAuthService, asType: AuthService),
 
     Singleton(classType: NavigationService),
 

--- a/packages/stacked/lib/src/code_generation/stacked_getit_annotations.dart
+++ b/packages/stacked/lib/src/code_generation/stacked_getit_annotations.dart
@@ -3,22 +3,25 @@ class DependencyRegistration {
   /// The type of the service to register
   final Type classType;
 
-  const DependencyRegistration({this.classType});
+  /// An abstracted class type of service to register
+  final Type asType;
+
+  const DependencyRegistration({this.classType, this.asType});
 }
 
 /// Registers the type passed in as a singleton instance in the get_it locator
 class Singleton extends DependencyRegistration {
-  const Singleton({Type classType}) : super(classType: classType);
+  const Singleton({Type classType, Type asType}) : super(classType: classType, asType: asType);
 }
 
 /// Registers the type passed in as a LazySingleton instance in the get_it locator
 class LazySingleton extends DependencyRegistration {
-  const LazySingleton({Type classType}) : super(classType: classType);
+  const LazySingleton({Type classType, Type asType}) : super(classType: classType, asType: asType);
 }
 
 /// Registers the type passed in as a Factory in the get_it locator
 class Factory extends DependencyRegistration {
-  const Factory({Type classType}) : super(classType: classType);
+  const Factory({Type classType, Type asType}) : super(classType: classType, asType: asType);
 }
 
 /// Registers the type passed in to be presolved using the function passed in
@@ -26,6 +29,6 @@ class Presolve extends DependencyRegistration {
   /// The static instance Future function to use for resolving the type registered
   final Future Function() presolveUsing;
 
-  const Presolve({Type classType, this.presolveUsing})
-      : super(classType: classType);
+  const Presolve({Type classType, this.presolveUsing, Type asType})
+      : super(classType: classType, asType: asType);
 }

--- a/packages/stacked_generator/lib/src/generators/getit/dependency_config.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/dependency_config.dart
@@ -5,8 +5,14 @@ class DependencyConfig {
   /// The import to use for the type of the service
   final String import;
 
+  /// The import to use for the abstracted service type
+  final String abstractedImport;
+
   /// The actual name of the class to be registered
   final String className;
+
+  /// The abstracted class name of the class to be registered
+  final String abstractedTypeClassName;
 
   /// The type of the service to register
   final DependencyType type;
@@ -16,7 +22,9 @@ class DependencyConfig {
 
   DependencyConfig({
     this.import,
+    this.abstractedImport,
     this.className,
+    this.abstractedTypeClassName,
     this.type,
     this.presolveFunction,
   });

--- a/packages/stacked_generator/lib/src/generators/getit/getit_locator_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/getit_locator_generator.dart
@@ -36,21 +36,24 @@ class GetItLocatorGenerator extends BaseGenerator {
     return stringBuffer.toString();
   }
 
-  String _getLocatorRegistrationStringForType(
-      DependencyConfig dependencyDefinition) {
+  String _getLocatorRegistrationStringForType(DependencyConfig dependencyDefinition) {
+    final hasAbstratedType = dependencyDefinition.abstractedTypeClassName != null;
+    final abstractionType =
+        hasAbstratedType ? '<${dependencyDefinition.abstractedTypeClassName}>' : '';
+
     switch (dependencyDefinition.type) {
       case DependencyType.LazySingleton:
-        return 'locator.registerLazySingleton(() => ${dependencyDefinition.className}());';
+        return 'locator.registerLazySingleton$abstractionType(() => ${dependencyDefinition.className}());';
       case DependencyType.PresolvedSingleton:
         return '''
         final ${dependencyDefinition.camelCaseClassName} = await ${dependencyDefinition.className}.${dependencyDefinition.presolveFunction}();
-        locator.registerSingleton(${dependencyDefinition.camelCaseClassName});
+        locator.registerSingleton$abstractionType(${dependencyDefinition.camelCaseClassName});
         ''';
       case DependencyType.Factory:
-        return 'locator.registerFactory(() => ${dependencyDefinition.className}());';
+        return 'locator.registerFactory$abstractionType(() => ${dependencyDefinition.className}());';
       case DependencyType.Singleton:
       default:
-        return 'locator.registerSingleton(${dependencyDefinition.className}());';
+        return 'locator.registerSingleton$abstractionType(${dependencyDefinition.className}());';
     }
   }
 
@@ -59,6 +62,7 @@ class GetItLocatorGenerator extends BaseGenerator {
     final imports = <String>{"package:stacked/stacked.dart"};
 
     imports.addAll(services.map((e) => e.import));
+    imports.addAll(services.map((e) => e.abstractedImport));
 
     var validImports = imports.where((import) => import != null).toSet();
     var dartImports =

--- a/packages/stacked_generator/lib/src/generators/getit/stacked_getit_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/stacked_getit_generator.dart
@@ -51,13 +51,15 @@ class StackedGetItGenerator extends GeneratorForAnnotation<StackedApp> {
     var dependencyReader = ConstantReader(dependencyConfig);
     // Get the type of the service that we want to register
     final dependencyClassType = dependencyReader.read('classType').typeValue;
+    final dependencyAbstractedClassType = dependencyReader.peek('asType')?.typeValue;
 
     throwIf(
       dependencyClassType == null,
-      '🛑 No depedency class Type defined for ${dependencyConfig.toString()}. Please make sure that any of the services provided to the services list in the StackedApp annotation has a service provided. Please see the documentation for stacked_generator if you don\'t know what this means.',
+      '🛑 No dependency class Type defined for ${dependencyConfig.toString()}. Please make sure that any of the services provided to the services list in the StackedApp annotation has a service provided. Please see the documentation for stacked_generator if you don\'t know what this means.',
     );
 
     final classElement = dependencyClassType.element as ClassElement;
+    final abstractedClassElement = dependencyAbstractedClassType?.element as ClassElement;
 
     throwIf(
       classElement == null,
@@ -66,8 +68,10 @@ class StackedGetItGenerator extends GeneratorForAnnotation<StackedApp> {
 
     // Get the import of the class type that's defined for the service
     final import = importResolver.resolve(classElement);
+    final abstractedImport = importResolver.resolve(abstractedClassElement);
 
     final className = dependencyClassType.getDisplayString();
+    final abstractedTypeClassName = dependencyAbstractedClassType?.getDisplayString();
 
     // NOTE: This can be used for actual dependency inject. We do service location instead.
     final constructor = classElement.unnamedConstructor;
@@ -84,7 +88,9 @@ class StackedGetItGenerator extends GeneratorForAnnotation<StackedApp> {
 
     return DependencyConfig(
       className: className,
+      abstractedTypeClassName: abstractedTypeClassName,
       import: import,
+      abstractedImport: abstractedImport,
       type: serviceType,
       presolveFunction: presolveFunction,
     );


### PR DESCRIPTION
re: https://github.com/FilledStacks/stacked/issues/228

Makes possible: 

```
@StackedApp(
  dependencies: [
    LazySingleton(classType: FirebaseAuthService, asType: AuthService),
])

// app.locator.dart
// ->   locator.registerLazySingleton<AuthService>(() => FirebaseAuthService());
```

