### PR TITLE
Fixes #232

### DIFF
--- a/packages/stacked_generator/.gitignore
+++ b/packages/stacked_generator/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/packages/stacked_generator/lib/src/generators/getit/stacked_locator_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/stacked_locator_generator.dart
@@ -60,13 +60,13 @@ class StackedLocatorGenerator extends GeneratorForAnnotation<StackedApp> {
 
     throwIf(
       classElement == null,
-      '🛑 ${dependencyClassType.getDisplayString()} is not a class element. All services should be classes. We don\'t register individual values for global access through the locator. Make sure the value provided as your service type is a class.',
+      '🛑 ${toDisplayString(dependencyClassType)} is not a class element. All services should be classes. We don\'t register individual values for global access through the locator. Make sure the value provided as your service type is a class.',
     );
 
     // Get the import of the class type that's defined for the service
     final import = importResolver.resolve(classElement);
 
-    final className = dependencyClassType.getDisplayString();
+    final className = toDisplayString(dependencyClassType);
 
     // NOTE: This can be used for actual dependency inject. We do service location instead.
     final constructor = classElement.unnamedConstructor;

--- a/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
@@ -24,7 +24,7 @@ class RouteConfigResolver {
     if (import != null) {
       routeConfig.imports.add(import);
     }
-    routeConfig.className = type.getDisplayString();
+    routeConfig.className = toDisplayString(type);
     var path = stackedRoute.peek('path')?.stringValue;
     if (path == null) {
       if (stackedRoute.peek('initial')?.boolValue == true) {
@@ -38,7 +38,7 @@ class RouteConfigResolver {
 
     throwIf(
       type.element is! ClassElement,
-      '${type.getDisplayString()} is not a class element',
+      '${toDisplayString(type)} is not a class element',
       element: type.element,
     );
 
@@ -48,7 +48,7 @@ class RouteConfigResolver {
         toLowerCamelCase(routeConfig.className);
 
     routeConfig.hasWrapper = classElement.allSupertypes
-        .map<String>((el) => el.getDisplayString())
+        .map<String>((el) => toDisplayString(el))
         .contains('StackedRouteWrapper');
 
     final constructor = classElement.unnamedConstructor;
@@ -57,7 +57,7 @@ class RouteConfigResolver {
     if (params?.isNotEmpty == true) {
       if (constructor.isConst &&
           params.length == 1 &&
-          params.first.type.getDisplayString() == 'Key') {
+          toDisplayString(params.first.type) == 'Key') {
         routeConfig.hasConstConstructor = true;
       } else {
         final paramResolver = RouteParameterResolver(_importResolver);
@@ -83,12 +83,12 @@ class RouteConfigResolver {
         ?.map((g) => g.toTypeValue())
         ?.forEach((guard) {
       routeConfig.guards.add(RouteGuardConfig(
-          type: guard.getDisplayString(),
+          type: toDisplayString(guard),
           import: _importResolver.resolve(guard.element)));
     });
 
     final returnType = stackedRoute.objectValue.type.typeArguments.first;
-    routeConfig.returnType = returnType.getDisplayString();
+    routeConfig.returnType = toDisplayString(returnType);
 
     if (routeConfig.returnType != 'dynamic') {
       routeConfig.imports.addAll(_importResolver.resolveAll(returnType));

--- a/packages/stacked_generator/lib/src/generators/router/route_parameter_config.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_parameter_config.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:stacked/stacked_annotations.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:source_gen/source_gen.dart';
+import 'package:stacked_generator/utils.dart';
 
 final pathParamChecker = TypeChecker.fromRuntime(PathParam);
 final queryParamChecker = TypeChecker.fromRuntime(QueryParam);
@@ -77,7 +78,7 @@ class RouteParameterResolver {
     }
 
     return RouteParamConfig(
-        type: paramType.getDisplayString(),
+        type: toDisplayString(paramType),
         name: parameterElement.name.replaceFirst("_", ''),
         alias: paramAlias,
         isPositional: parameterElement.isPositional,

--- a/packages/stacked_generator/lib/utils.dart
+++ b/packages/stacked_generator/lib/utils.dart
@@ -16,6 +16,18 @@ String toKababCase(String s) {
       (match) => '${match.group(1)}-${match.group(2)}'.toLowerCase());
 }
 
+String toDisplayString(dynamic e) {
+  try {
+    return e.getDisplayString(withNullability: false) as String;
+  } catch (error) {
+    if (error is TypeError) {
+      return e.getDisplayString() as String;
+    } else {
+      rethrow;
+    }
+  }
+}
+
 void throwIf(bool condition, String message, {Element element, String todo}) {
   if (condition) {
     throwError(message, todo: todo, element: element);


### PR DESCRIPTION
I had the similar problem description as the submitter of Issue #232. The problems stems from using an analyzer version that requires the ```withNullability``` argument on ```.getDisplayString()```. This was an [issue](https://github.com/hivedb/hive/commit/24c4c418b15d12d88cc8400aca8638a03a783558) in the hive codebase as well. Their fix handles an edge case I wasn't personally considering when I fixed it originally, so I implemented their fix.

I uncommented ```.vscode/``` in the gitignore, because I needed to override my user-level settings to not alter the code formatting the stacked package has chosen. I didn't see any conflicts with this ignore amendment within the stacked_generator project. 