### PR TITLE
Removes the warning from the get package

### DIFF
--- a/packages/stacked_services/lib/src/navigation_service.dart
+++ b/packages/stacked_services/lib/src/navigation_service.dart
@@ -98,7 +98,7 @@ class NavigationService {
       Duration duration,
       bool popGesture,
       int id}) {
-    return Get.to(page,
+    return Get.to(() => page,
         transition: _getTransitionOrDefault(transition),
         duration: duration ?? Get.defaultTransitionDuration,
         popGesture: popGesture ?? Get.isPopGestureEnable,
@@ -149,7 +149,7 @@ class NavigationService {
 
   /// Pushes [view] onto the navigation stack
   Future<dynamic> navigateToView(Widget view, {dynamic arguments, int id}) {
-    return Get.to(view, arguments: arguments, id: id);
+    return Get.to(() => view, arguments: arguments, id: id);
   }
 
   /// Replaces the current route with the [routeName]


### PR DESCRIPTION
This will remove the following warning
[38;5;244m[GETX] [39;49mWARNING, consider using: "Get.to(() => Page())" instead of "Get.to(Page())".
       Using a widget function instead of a widget fully guarantees that the widget and its controllers will be removed from memory when they are no longer used.