### PR TITLE
Fixes #249

### DIFF
--- a/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
@@ -239,7 +239,7 @@ class SnackbarService {
       return null;
     }
 
-    return FlatButton(
+    return TextButton(
       child: Text(
         mainButtonTitle,
         style: TextStyle(


### PR DESCRIPTION
Complies with "Replaced reference to obsolete FlatButton button class in SnackBar" [#65988](https://github.com/flutter/flutter/pull/65988/files)