### PR TITLE
Support change notifier in ReactiveServiceMixin

### DIFF
--- a/packages/stacked/lib/src/state_management/reactive_service_mixin.dart
+++ b/packages/stacked/lib/src/state_management/reactive_service_mixin.dart
@@ -14,6 +14,8 @@ mixin ReactiveServiceMixin {
         reactiveValue.onChange.listen((event) => notifyListeners());
       } else if (reactiveValue is RxSet) {
         reactiveValue.onChange.listen((event) => notifyListeners());
+      } else if (reactiveValue is ChangeNotifier) {
+        (reactiveValue as ChangeNotifier).notifyListeners();
       }
     }
   }


### PR DESCRIPTION
Disclaimer: this is my first ever contribution to open source. Please leave a comment if I did something wrong ;)

Description:
This PR adds support for `ChangeNotifier` in `ReactiveServiceMixin`, i.e our service can just extend the `ChangeNotifier` and does not have to use `observable_ish` values.

Then, instead of having to pass in different RxValues we can just do this:

`listenToReactiveValues([this])`

inside our ReactiveService class (that has to extend ChangeNotifier though)


