### PR TITLE
Hot Reload of Localised Strings

### DIFF
--- a/packages/stacked_localisation/stacked_localisation/example/lib/main.dart
+++ b/packages/stacked_localisation/stacked_localisation/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Router;
 import 'package:stacked_localisation/stacked_localisation.dart';
 import 'package:stacked_services/stacked_services.dart';
 

--- a/packages/stacked_localisation/stacked_localisation/lib/src/localisation_service.dart
+++ b/packages/stacked_localisation/stacked_localisation/lib/src/localisation_service.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/material.dart';
 import 'package:stacked_localisation/src/setup_locator.dart';
 import 'package:stacked_localisation/src/utils/locale_provider.dart';
 import 'package:stacked_localisation/src/utils/string_reader.dart';
 
-class LocalisationService {
+class LocalisationService with WidgetsBindingObserver {
   final _localeProvider = locator<LocaleProvider>();
   final _stringReader = locator<StringReader>();
 
@@ -15,6 +16,10 @@ class LocalisationService {
       await _instance.initialise();
     }
     return _instance;
+  }
+
+  LocalisationService() {
+    WidgetsBinding.instance.addObserver(this);
   }
 
   /// Stores the Strings for the locale that the service was initialised with
@@ -33,4 +38,19 @@ class LocalisationService {
     locator.registerLazySingleton(() => LocaleProvider());
     locator.registerLazySingleton(() => StringReader());
   }
+
+  @override
+  void didChangeLocales(List<Locale> locale) async {
+    final currentLocale = locale.first.toString();
+    _localisedStrings = await _stringReader.getStringsFromAssets(currentLocale);
+  }
+
+  // @override
+  // void didChangeAppLifecycleState(AppLifecycleState state) async {
+  //   // If the user changes language on the device and come back to the app,
+  //   // it will trigger this function with AppLifecycleState.resumed
+  //   if (state == AppLifecycleState.resumed) {
+  //     await _instance.initialise();
+  //   }
+  // }
 }


### PR DESCRIPTION
## Summary
This is an attempt to implement the "Hot Reload" feature for `stacked_localisation` when the user changes the device's language. (Issue brought up in #126)

## Details
- 4fd5fe0
  - the example app provided in `/example` couldn't be start up due to `ambiguous_import` error as the `Router` class is defined in both `package:example/core/router.gr.dart` and `package:flutter/src/widgets/router.dart`.
  - this is solved by hiding the `Router` class provided in `flutter/material.dart`.
- e1b0f08
  - by adding `WidgetsBindingObserver` functionality to `LocalisationService`, we get access to `didChangeLocales()` and `didChangeAppLifecycleState()` callbacks.
  - there are two different ways of implementation that will load up the new strings (of the new selected device's language) and place them into memory.
  - implementation with `didChangeLocales()`: since we have access to the devices' `locale` from the callback function, we just have to update `_localisedStrings` with `getStringsFromAssets` instead of running `initialise()`.
  ```dart
  @override
  void didChangeLocales(List<Locale> locale) async {
    final currentLocale = locale.first.toString();
    _localisedStrings = await _stringReader.getStringsFromAssets(currentLocale);
  }
  ```
  - implementation with `didChangeAppLifecycleState()`: run `initialise()` everytime the app is brought up from background.
  ```dart
  @override
  void didChangeAppLifecycleState(AppLifecycleState state) async {
    // If the user changes language on the device and come back to the app,
    // it will trigger this function with AppLifecycleState.resumed
    if (state == AppLifecycleState.resumed) {
      await _instance.initialise();
    }
  }
  ```

### Current Progress

<img src="https://user-images.githubusercontent.com/44340199/110740220-09f90a80-8276-11eb-88fb-2a1b55c98d73.gif" height="500"/>

As shown in the GIF above, after we change the device's language from en to af
- contents in `HomeView` stayed in en
- contents in the dialog changed to af

From this, we know that `didChangeLocales()` callback ran and updated `_localisedStrings`.
However, `HomeView` is not rerendered after `didChangeLocales()` callback in LocalisationService.
`HomeView` will rerender when we perform Flutter Hot Reload.

❓ Not sure if it's possible to trigger rendering of `HomeView` from LocalisationService after `_localisedString` is updated.