### PR TITLE
Replaced flutter_facebook_login with flutter_facebook_auth

### DIFF
--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -201,6 +201,8 @@ class FirebaseAuthenticationService {
         case FacebookAuthErrorCode.FAILED:
           return FirebaseAuthenticationResult.error(
               errorMessage: 'Facebook login has failed');
+        default:
+          return FirebaseAuthenticationResult.error(errorMessage: e.toString());
       }
     } catch (e) {
       log?.e(e);

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -191,9 +191,18 @@ class FirebaseAuthenticationService {
       return await _handleAccountExists(e);
     } on FacebookAuthException catch (e) {
       log?.e(e);
-      if(e.errorCode == FacebookAuthErrorCode.CANCELLED) return null;
-
-      return FirebaseAuthenticationResult.error(errorMessage: e.toString());
+      switch (e.errorCode) {
+        case FacebookAuthErrorCode.OPERATION_IN_PROGRESS:
+          return FirebaseAuthenticationResult.error(
+              errorMessage:
+                  'You have a previous Facebook login operation in progress');
+        case FacebookAuthErrorCode.CANCELLED:
+          return FirebaseAuthenticationResult.error(
+              errorMessage: 'Facebook login has been cancelled by the user');
+        case FacebookAuthErrorCode.FAILED:
+          return FirebaseAuthenticationResult.error(
+              errorMessage: 'Facebook login has failed');
+      }
     } catch (e) {
       log?.e(e);
       return FirebaseAuthenticationResult.error(errorMessage: e.toString());

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -73,7 +73,7 @@ class FirebaseAuthenticationService {
         idToken: googleSignInAuthentication.idToken,
       );
 
-      var result = await _signInWithCredential(credential);
+      final result = await _signInWithCredential(credential);
 
       // Link the pending credential with the existing account
       if (_pendingCredential != null) {
@@ -142,7 +142,7 @@ class FirebaseAuthenticationService {
         rawNonce: rawNonce,
       );
 
-      var result = await _signInWithCredential(credential);
+      final result = await _signInWithCredential(credential);
 
       // Link the pending credential with the existing account
       if (_pendingCredential != null) {
@@ -173,7 +173,7 @@ class FirebaseAuthenticationService {
       final FacebookAuthCredential facebookCredentials =
           FacebookAuthProvider.credential(accessToken.token);
 
-      var result = await _signInWithCredential(facebookCredentials);
+      final result = await _signInWithCredential(facebookCredentials);
 
       // Link the pending credential with the existing account
       if (_pendingCredential != null) {
@@ -214,7 +214,7 @@ class FirebaseAuthenticationService {
   }) async {
     try {
       log?.d('email:$email');
-      var result = await _firebaseAuth.signInWithEmailAndPassword(
+      final result = await _firebaseAuth.signInWithEmailAndPassword(
         email: email,
         password: password,
       );
@@ -248,7 +248,7 @@ class FirebaseAuthenticationService {
       {String email, String password}) async {
     try {
       log?.d('email:$email');
-      var result = await _firebaseAuth.createUserWithEmailAndPassword(
+      final result = await _firebaseAuth.createUserWithEmailAndPassword(
         email: email,
         password: password,
       );

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -62,7 +62,8 @@ class FirebaseAuthenticationService {
           await _googleSignIn.signIn();
       if (googleSignInAccount == null) {
         log?.i('Process is canceled by the user');
-        return null;
+        return FirebaseAuthenticationResult.error(
+            errorMessage: 'Google Sign In has been cancelled by the user');
       }
       final GoogleSignInAuthentication googleSignInAuthentication =
           await googleSignInAccount.authentication;
@@ -157,8 +158,6 @@ class FirebaseAuthenticationService {
       log?.e(e);
       return await _handleAccountExists(e);
     } on SignInWithAppleAuthorizationException catch (e) {
-      if (e.code == AuthorizationErrorCode.canceled) return null;
-
       return FirebaseAuthenticationResult.error(errorMessage: e.toString());
     } catch (e) {
       log?.e(e);

--- a/packages/stacked_firebase_auth/pubspec.yaml
+++ b/packages/stacked_firebase_auth/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   # Firebase Authentications
   google_sign_in: ^4.5.6
   sign_in_with_apple: ^2.5.4
-  flutter_facebook_login: ^3.0.0
+  flutter_facebook_auth: ^2.0.2+1
 
   # logging
   logger: ^0.9.0


### PR DESCRIPTION
Replaced [flutter_facebook_login](https://pub.dev/packages/flutter_facebook_login) with [flutter_facebook_auth](https://pub.dev/packages/flutter_facebook_auth) because it is better maintained and it is used in [FlutterFire Facebook social auth documentation](https://firebase.flutter.dev/docs/auth/social#facebook).