### PR TITLE
[stacked_firebase_auth] Return firebase user, exposed firebaseAuth for easier access, bumped versions for Google, Apple and Facebook plugins

### DIFF
--- a/packages/stacked_firebase_auth/pubspec.yaml
+++ b/packages/stacked_firebase_auth/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
   firebase_auth: ^1.0.1
 
   # Firebase Authentications
-  google_sign_in: ^4.5.6
-  sign_in_with_apple: ^2.5.4
-  flutter_facebook_auth: ^2.0.2+1
+  google_sign_in: ^5.0.1
+  sign_in_with_apple: ^3.0.0
+  flutter_facebook_auth: ^3.1.1
 
   # logging
   logger: ^0.9.0


### PR DESCRIPTION
Related to #267 discussion

Changed FirebaseAuthenticationResult to return Firebase User object instead of only uid and userToken.

Made firebaseAuth public for easier access from FirebaseAuthenticationService.

Bumped versions to latest for Google, Apple and Facebook plugins. 
This was needed for fixing a version solving failed problem with the latest firebase_core and current flutter_facebook_auth.
```
Because flutter_facebook_auth >=2.0.0-web.8 <3.0.0-nullsafety.0 depends on flutter_facebook_auth_platform_interface ^1.0.1 which depends on plugin_platform_interface ^1.0.1, flutter_facebook_auth >=2.0.0-web.8 <3.0.0-nullsafety.0 requires plugin_platform_interf0-nullsafety.0 requires plugin_platform_interface ^1.0.1.
And because firebase_core >=1.0.0 depends on firebase_core_platform_interface ^4.0.0 which depends on plugin_platform_interface ^2.0.0, flutter_facebook_auth >=2.0.0-web.8 <3.0.0-nullsafety.0 is incompatible with firebase_core >=1.0.0.rebase_core >=1.0.0.
So, because stacked_firebase_auth depends on both firebase_core ^1.0.1 and flutter_facebook_auth ^2.0.2+1, version solving failed.
```