### PR TITLE
Adds large text form field to the example app

### DIFF
--- a/packages/stacked/example/lib/ui/form/example_form_view.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.dart
@@ -14,7 +14,16 @@ import 'example_form_viewmodel.dart';
   FormDateField(name: 'birthDate'),
   FormDropdownField(
     name: 'doYouLoveFood',
-    items: ['Yes', 'No'],
+    items: [
+      StaticDropdownItem(
+        title: 'Yes',
+        value: 'YesDr',
+      ),
+      StaticDropdownItem(
+        title: 'No',
+        value: 'NoDr',
+      ),
+    ],
   )
 ])
 // #2: with $ExampleFormView
@@ -27,7 +36,7 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
       onModelReady: (model) {
         // #3: Listen to text updates by calling listenToFormUpdated(model);
         listenToFormUpdated(model);
-        model.setDoYouLoveFood(DoYouLoveFoodValues.first);
+        model.setDoYouLoveFood(DoYouLoveFoodValueToTitleMap.keys.first);
       },
       builder: (context, model, child) => Scaffold(
         floatingActionButton: FloatingActionButton(
@@ -112,12 +121,14 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                       onChanged: (value) {
                         model.setDoYouLoveFood(value!);
                       },
-                      items: DoYouLoveFoodValues.map(
-                        (e) => DropdownMenuItem<String>(
-                          value: e,
-                          child: Text(e),
-                        ),
-                      ).toList(),
+                      items: DoYouLoveFoodValueToTitleMap.keys
+                          .map(
+                            (value) => DropdownMenuItem<String>(
+                              value: value,
+                              child: Text(DoYouLoveFoodValueToTitleMap[value]!),
+                            ),
+                          )
+                          .toList(),
                     )
                   ],
                 )

--- a/packages/stacked/example/lib/ui/form/example_form_view.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.dart
@@ -10,6 +10,10 @@ import 'example_form_viewmodel.dart';
   FormTextField(name: 'email'),
   FormTextField(name: 'password', isPassword: true),
   FormDateField(name: 'birthDate'),
+  FormDropdownField(
+    name: 'orderSize',
+    items: ['Extra Large', 'Large', 'Medium', 'Small', 'Extra Small'],
+  )
 ])
 // #2: with $ExampleFormView
 class ExampleFormView extends StatelessWidget with $ExampleFormView {
@@ -78,6 +82,19 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                   ),
                 ),
                 SizedBox(height: 15),
+                DropdownButton<String>(
+                  value: model.hasOrderSize
+                      ? model.orderSizeValue
+                      : OrderSizeValues.first,
+                  onChanged: (orderSize) {
+                    model.setOrderSize(orderSize!);
+                  },
+                  items: OrderSizeValues.map(
+                    (e) => DropdownMenuItem<String>(
+                      child: Text(e),
+                    ),
+                  ).toList(),
+                )
               ],
             ),
           ),

--- a/packages/stacked/example/lib/ui/form/example_form_view.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked/stacked_annotations.dart';
 
@@ -9,10 +10,11 @@ import 'example_form_viewmodel.dart';
 @FormView(fields: [
   FormTextField(name: 'email'),
   FormTextField(name: 'password', isPassword: true),
+  FormTextField(name: 'shortBio'),
   FormDateField(name: 'birthDate'),
   FormDropdownField(
-    name: 'orderSize',
-    items: ['Extra Large', 'Large', 'Medium', 'Small', 'Extra Small'],
+    name: 'doYouLoveFood',
+    items: ['Yes', 'No'],
   )
 ])
 // #2: with $ExampleFormView
@@ -25,6 +27,7 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
       onModelReady: (model) {
         // #3: Listen to text updates by calling listenToFormUpdated(model);
         listenToFormUpdated(model);
+        model.setDoYouLoveFood(DoYouLoveFoodValues.first);
       },
       builder: (context, model, child) => Scaffold(
         floatingActionButton: FloatingActionButton(
@@ -59,6 +62,8 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                     //#5: Set password passwordController and focus node
                     controller: passwordController,
                     decoration: InputDecoration(hintText: 'password'),
+                    keyboardType: TextInputType.visiblePassword,
+                    obscureText: true,
                     focusNode: passwordFocusNode,
                     onFieldSubmitted: (_) => model.saveData(),
                   ),
@@ -68,6 +73,22 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                     model.validationMessage!,
                     style: TextStyle(color: Colors.red),
                   ),
+                SizedBox(height: 15),
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxWidth: 300,
+                  ),
+                  child: TextField(
+                    //#6: Set shortBio shortBioController and focus node
+                    maxLines: null,
+                    keyboardType: TextInputType.multiline,
+                    controller: shortBioController,
+                    decoration: InputDecoration(
+                      hintText: 'Tell us a bit more about yourself',
+                    ),
+                    focusNode: shortBioFocusNode,
+                  ),
+                ),
                 SizedBox(height: 15),
                 ElevatedButton(
                   onPressed: () => model.selectBirthDate(
@@ -82,18 +103,23 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                   ),
                 ),
                 SizedBox(height: 15),
-                DropdownButton<String>(
-                  value: model.hasOrderSize
-                      ? model.orderSizeValue
-                      : OrderSizeValues.first,
-                  onChanged: (orderSize) {
-                    model.setOrderSize(orderSize!);
-                  },
-                  items: OrderSizeValues.map(
-                    (e) => DropdownMenuItem<String>(
-                      child: Text(e),
-                    ),
-                  ).toList(),
+                Row(
+                  children: [
+                    Text('Do you love food?'),
+                    SizedBox(width: 15),
+                    DropdownButton<String>(
+                      value: model.doYouLoveFoodValue,
+                      onChanged: (value) {
+                        model.setDoYouLoveFood(value!);
+                      },
+                      items: DoYouLoveFoodValues.map(
+                        (e) => DropdownMenuItem<String>(
+                          value: e,
+                          child: Text(e),
+                        ),
+                      ).toList(),
+                    )
+                  ],
                 )
               ],
             ),

--- a/packages/stacked/example/lib/ui/form/example_form_view.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.dart
@@ -61,7 +61,7 @@ class ExampleFormView extends StatelessWidget with $ExampleFormView {
                 ),
                 if (model.showValidation)
                   Text(
-                    model.validationMessage,
+                    '${model.validationMessage}',
                     style: TextStyle(color: Colors.red),
                   ),
                 SizedBox(height: 15),

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -15,10 +15,10 @@ const String ShortBioValueKey = 'shortBio';
 const String BirthDateValueKey = 'birthDate';
 const String DoYouLoveFoodValueKey = 'doYouLoveFood';
 
-const List<String> DoYouLoveFoodValues = [
-  'Yes',
-  'No',
-];
+const Map<String, String> DoYouLoveFoodValueToTitleMap = {
+  'YesDr': 'Yes',
+  'NoDr': 'No',
+};
 
 mixin $ExampleFormView on StatelessWidget {
   final TextEditingController emailController = TextEditingController();

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -12,6 +12,15 @@ import 'package:stacked/stacked.dart';
 const String EmailValueKey = 'email';
 const String PasswordValueKey = 'password';
 const String BirthDateValueKey = 'birthDate';
+const String OrderSizeValueKey = 'orderSize';
+
+const List<String> OrderSizeValues = [
+  'Extra Large',
+  'Large',
+  'Medium',
+  'Small',
+  'Extra Small',
+];
 
 mixin $ExampleFormView on StatelessWidget {
   final TextEditingController emailController = TextEditingController();
@@ -48,10 +57,12 @@ extension ValueProperties on FormViewModel {
   String get emailValue => this.formValueMap[EmailValueKey];
   String get passwordValue => this.formValueMap[PasswordValueKey];
   DateTime get birthDateValue => this.formValueMap[BirthDateValueKey];
+  String get orderSizeValue => this.formValueMap[OrderSizeValueKey];
 
   bool get hasEmail => this.formValueMap.containsKey(EmailValueKey);
   bool get hasPassword => this.formValueMap.containsKey(PasswordValueKey);
   bool get hasBirthDate => this.formValueMap.containsKey(BirthDateValueKey);
+  bool get hasOrderSize => this.formValueMap.containsKey(OrderSizeValueKey);
 }
 
 extension Methods on FormViewModel {
@@ -69,5 +80,9 @@ extension Methods on FormViewModel {
       this.setData(
           this.formValueMap..addAll({BirthDateValueKey: selectedDate}));
     }
+  }
+
+  void setOrderSize(String orderSize) {
+    this.setData(this.formValueMap..addAll({OrderSizeValueKey: orderSize}));
   }
 }

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -56,10 +56,10 @@ extension ValueProperties on FormViewModel {
 
 extension Methods on FormViewModel {
   Future<void> selectBirthDate(
-      {@required BuildContext context,
-      @required DateTime initialDate,
-      @required DateTime firstDate,
-      @required DateTime lastDate}) async {
+      {required BuildContext context,
+      required DateTime initialDate,
+      required DateTime firstDate,
+      required DateTime lastDate}) async {
     final selectedDate = await showDatePicker(
         context: context,
         initialDate: initialDate,

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -11,28 +11,29 @@ import 'package:stacked/stacked.dart';
 
 const String EmailValueKey = 'email';
 const String PasswordValueKey = 'password';
+const String ShortBioValueKey = 'shortBio';
 const String BirthDateValueKey = 'birthDate';
-const String OrderSizeValueKey = 'orderSize';
+const String DoYouLoveFoodValueKey = 'doYouLoveFood';
 
-const List<String> OrderSizeValues = [
-  'Extra Large',
-  'Large',
-  'Medium',
-  'Small',
-  'Extra Small',
+const List<String> DoYouLoveFoodValues = [
+  'Yes',
+  'No',
 ];
 
 mixin $ExampleFormView on StatelessWidget {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final TextEditingController shortBioController = TextEditingController();
   final FocusNode emailFocusNode = FocusNode();
   final FocusNode passwordFocusNode = FocusNode();
+  final FocusNode shortBioFocusNode = FocusNode();
 
   /// Registers a listener on every generated controller that calls [model.setData()]
   /// with the latest textController values
   void listenToFormUpdated(FormViewModel model) {
     emailController.addListener(() => _updateFormData(model));
     passwordController.addListener(() => _updateFormData(model));
+    shortBioController.addListener(() => _updateFormData(model));
   }
 
   /// Updates the formData on the FormViewModel
@@ -41,6 +42,7 @@ mixin $ExampleFormView on StatelessWidget {
           ..addAll({
             EmailValueKey: emailController.text,
             PasswordValueKey: passwordController.text,
+            ShortBioValueKey: shortBioController.text,
           }),
       );
 
@@ -50,18 +52,23 @@ mixin $ExampleFormView on StatelessWidget {
 
     emailController.dispose();
     passwordController.dispose();
+    shortBioController.dispose();
   }
 }
 
 extension ValueProperties on FormViewModel {
   String? get emailValue => this.formValueMap[EmailValueKey];
   String? get passwordValue => this.formValueMap[PasswordValueKey];
+  String? get shortBioValue => this.formValueMap[ShortBioValueKey];
   DateTime? get birthDateValue => this.formValueMap[BirthDateValueKey];
+  String? get doYouLoveFoodValue => this.formValueMap[DoYouLoveFoodValueKey];
 
   bool get hasEmail => this.formValueMap.containsKey(EmailValueKey);
   bool get hasPassword => this.formValueMap.containsKey(PasswordValueKey);
+  bool get hasShortBio => this.formValueMap.containsKey(ShortBioValueKey);
   bool get hasBirthDate => this.formValueMap.containsKey(BirthDateValueKey);
-  bool get hasOrderSize => this.formValueMap.containsKey(OrderSizeValueKey);
+  bool get hasDoYouLoveFood =>
+      this.formValueMap.containsKey(DoYouLoveFoodValueKey);
 }
 
 extension Methods on FormViewModel {
@@ -81,7 +88,8 @@ extension Methods on FormViewModel {
     }
   }
 
-  void setOrderSize(String orderSize) {
-    this.setData(this.formValueMap..addAll({OrderSizeValueKey: orderSize}));
+  void setDoYouLoveFood(String doYouLoveFood) {
+    this.setData(
+        this.formValueMap..addAll({DoYouLoveFoodValueKey: doYouLoveFood}));
   }
 }

--- a/packages/stacked/example/pubspec.yaml
+++ b/packages/stacked/example/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   stacked_hooks:
   flutter_hooks:
   stacked_themes:
+    path: ../../stacked_themes/
 
   # navigation
   get:

--- a/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
+++ b/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
@@ -28,7 +28,13 @@ class FormDateField extends FormField {
 }
 
 class FormDropdownField extends FormField {
-  final List<String> items;
+  final List<StaticDropdownItem> items;
   const FormDropdownField({String? name, required this.items})
       : super(name: name);
+}
+
+class StaticDropdownItem {
+  final String title;
+  final String value;
+  const StaticDropdownItem({required this.title, required this.value});
 }

--- a/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
+++ b/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
@@ -1,7 +1,7 @@
 /// The annotation to be used for a view that contains a Form
 class FormView {
   /// The list of form fields to generate
-  final List<FormTextField>? fields;
+  final List<FormField>? fields;
 
   const FormView({this.fields});
 }

--- a/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
+++ b/packages/stacked/lib/src/code_generation/forms/stacked_form_annotations.dart
@@ -26,3 +26,9 @@ class FormTextField extends FormField {
 class FormDateField extends FormField {
   const FormDateField({String? name}) : super(name: name);
 }
+
+class FormDropdownField extends FormField {
+  final List<String> items;
+  const FormDropdownField({String? name, required this.items})
+      : super(name: name);
+}

--- a/packages/stacked_generator/lib/src/generators/forms/field_config.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/field_config.dart
@@ -18,9 +18,16 @@ class DateFieldConfig extends FieldConfig {
 }
 
 class DropdownFieldConfig extends FieldConfig {
-  final List<String> items;
+  final List<DropdownFieldItem> items;
   const DropdownFieldConfig({required String name, required this.items})
       : super(name: name);
+}
+
+class DropdownFieldItem {
+  final String title;
+  final String value;
+
+  DropdownFieldItem({required this.title, required this.value});
 }
 
 extension ListOfFieldConfigs on List<FieldConfig> {

--- a/packages/stacked_generator/lib/src/generators/forms/field_config.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/field_config.dart
@@ -17,6 +17,12 @@ class DateFieldConfig extends FieldConfig {
   DateFieldConfig({required String name}) : super(name: name);
 }
 
+class DropdownFieldConfig extends FieldConfig {
+  final List<String> items;
+  const DropdownFieldConfig({required String name, required this.items})
+      : super(name: name);
+}
+
 extension ListOfFieldConfigs on List<FieldConfig> {
   List<TextFieldConfig> get onlyTextFieldConfigs => this
       .where((fieldConfig) => fieldConfig is TextFieldConfig)
@@ -26,5 +32,10 @@ extension ListOfFieldConfigs on List<FieldConfig> {
   List<DateFieldConfig> get onlyDateFieldConfigs => this
       .where((fieldConfig) => fieldConfig is DateFieldConfig)
       .map((t) => t as DateFieldConfig)
+      .toList();
+
+  List<DropdownFieldConfig> get onlyDropdownFieldConfigs => this
+      .where((fieldConfig) => fieldConfig is DropdownFieldConfig)
+      .map((t) => t as DropdownFieldConfig)
       .toList();
 }

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
@@ -18,7 +18,7 @@ class StackedFormContentGenerator extends BaseGenerator {
     // and can then be unit tested to avoid simple mistakes. BUT, that's for later.
     _generateImports();
     _generateValueMapKeys(fields);
-    _generateDropdownItemsList(fields.onlyDropdownFieldConfigs);
+    _generateDropdownItemsMap(fields.onlyDropdownFieldConfigs);
     _generateFormMixin();
     _generateFormViewModelExtensions(fields);
 
@@ -35,16 +35,17 @@ class StackedFormContentGenerator extends BaseGenerator {
     newLine();
   }
 
-  void _generateDropdownItemsList(List<DropdownFieldConfig> fields) {
+  void _generateDropdownItemsMap(List<DropdownFieldConfig> fields) {
     newLine();
     for (var field in fields) {
       final caseName = ReCase(field.name);
-      writeLine("const List<String> ${caseName.pascalCase}Values = [");
+      writeLine(
+          "const Map<String, String> ${caseName.pascalCase}ValueToTitleMap = {");
       for (final item in field.items) {
-        writeLine("'$item',");
+        writeLine("'${item.value}': '${item.title}',");
       }
     }
-    writeLine('];');
+    if (fields.isNotEmpty) writeLine('};');
     newLine();
   }
 

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
@@ -18,6 +18,7 @@ class StackedFormContentGenerator extends BaseGenerator {
     // and can then be unit tested to avoid simple mistakes. BUT, that's for later.
     _generateImports();
     _generateValueMapKeys(fields);
+    _generateDropdownItemsList(fields.onlyDropdownFieldConfigs);
     _generateFormMixin();
     _generateFormViewModelExtensions(fields);
 
@@ -31,6 +32,19 @@ class StackedFormContentGenerator extends BaseGenerator {
       writeLine(
           "const String ${_getFormKeyName(caseName)} = '${caseName.camelCase}';");
     }
+    newLine();
+  }
+
+  void _generateDropdownItemsList(List<DropdownFieldConfig> fields) {
+    newLine();
+    for (var field in fields) {
+      final caseName = ReCase(field.name);
+      writeLine("const List<String> ${caseName.pascalCase}Values = [");
+      for (final item in field.items) {
+        writeLine("'$item',");
+      }
+    }
+    writeLine('];');
     newLine();
   }
 
@@ -192,11 +206,24 @@ class StackedFormContentGenerator extends BaseGenerator {
       newLine();
     }
 
+    // Generate the drop down selected item setter
+    for (final field in fields.onlyDropdownFieldConfigs) {
+      final caseName = ReCase(field.name);
+      writeLine('''
+          void set${caseName.pascalCase}(String ${caseName.camelCase}) {
+            this.setData(this.formValueMap..addAll({${_getFormKeyName(caseName)}: ${caseName.camelCase}}));
+          }
+    ''');
+      newLine();
+    }
+
     writeLine('}');
   }
 
   String _getFormFieldValueType(FieldConfig field) {
-    return field is TextFieldConfig ? 'String' : 'DateTime';
+    return field is TextFieldConfig || field is DropdownFieldConfig
+        ? 'String'
+        : 'DateTime';
   }
 
   String _getControllerName(FieldConfig field) => '${field.name}Controller';

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
@@ -174,10 +174,10 @@ class StackedFormContentGenerator extends BaseGenerator {
       final caseName = ReCase(field.name);
       writeLine('''
           Future<void> select${caseName.pascalCase}(
-              {@required BuildContext context,
-              @required DateTime initialDate,
-              @required DateTime firstDate,
-              @required DateTime lastDate}) async {
+              {required BuildContext context,
+              required DateTime initialDate,
+              required DateTime firstDate,
+              required DateTime lastDate}) async {
             final selectedDate = await showDatePicker(
                 context: context,
                 initialDate: initialDate,

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
@@ -65,8 +65,8 @@ FieldConfig _readFieldConfig({
 }
 
 FieldConfig _readTextFieldConfig({
-  ConstantReader fieldReader,
-  ImportResolver importResolver,
+  required ConstantReader fieldReader,
+  required ImportResolver importResolver,
 }) {
   final String name = (fieldReader.peek('name')?.stringValue) ?? '';
   return TextFieldConfig(
@@ -75,8 +75,8 @@ FieldConfig _readTextFieldConfig({
 }
 
 FieldConfig _readDateFieldConfig({
-  ConstantReader fieldReader,
-  ImportResolver importResolver,
+  required ConstantReader fieldReader,
+  required ImportResolver importResolver,
 }) {
   final String name = (fieldReader.peek('name')?.stringValue) ?? '';
   return DateFieldConfig(

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
@@ -94,11 +94,15 @@ FieldConfig _readDropdownFieldConfig({
   required ImportResolver importResolver,
 }) {
   final String name = (fieldReader.peek('name')?.stringValue) ?? '';
-  final List<String> items =
+  final List<DropdownFieldItem> items =
       (fieldReader.peek('items')?.listValue.map((dartObject) {
-            return ConstantReader(dartObject).stringValue;
+            final itemReader = ConstantReader(dartObject);
+            final title = itemReader.peek('title')?.stringValue ?? '';
+            final value = itemReader.peek('value')?.stringValue ?? '';
+
+            return DropdownFieldItem(title: title, value: value);
           }).toList()) ??
-          <String>[];
+          <DropdownFieldItem>[];
   return DropdownFieldConfig(
     name: name,
     items: items,

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_generator.dart
@@ -52,12 +52,17 @@ FieldConfig _readFieldConfig({
       fieldReader.instanceOf(TypeChecker.fromRuntime(FormTextField));
   bool isDateField =
       fieldReader.instanceOf(TypeChecker.fromRuntime(FormDateField));
+  bool isDropdownField =
+      fieldReader.instanceOf(TypeChecker.fromRuntime(FormDropdownField));
 
   if (isTextField) {
     return _readTextFieldConfig(
         fieldReader: fieldReader, importResolver: importResolver);
   } else if (isDateField) {
     return _readDateFieldConfig(
+        fieldReader: fieldReader, importResolver: importResolver);
+  } else if (isDropdownField) {
+    return _readDropdownFieldConfig(
         fieldReader: fieldReader, importResolver: importResolver);
   } else {
     throw ArgumentError('Unknown form field $fieldConfig');
@@ -81,5 +86,21 @@ FieldConfig _readDateFieldConfig({
   final String name = (fieldReader.peek('name')?.stringValue) ?? '';
   return DateFieldConfig(
     name: name,
+  );
+}
+
+FieldConfig _readDropdownFieldConfig({
+  required ConstantReader fieldReader,
+  required ImportResolver importResolver,
+}) {
+  final String name = (fieldReader.peek('name')?.stringValue) ?? '';
+  final List<String> items =
+      (fieldReader.peek('items')?.listValue.map((dartObject) {
+            return ConstantReader(dartObject).stringValue;
+          }).toList()) ??
+          <String>[];
+  return DropdownFieldConfig(
+    name: name,
+    items: items,
   );
 }

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   # logger: ^0.9.0
   recase: ^4.0.0-nullsafety.0
   stacked:
-    ^2.0.0-nullsafety.3
-    # path: ../stacked
+    # ^2.0.0-nullsafety.1
+    path: ../stacked
 
 dev_dependencies:
   build_runner: ^1.11.5

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.4
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,8 +14,7 @@ dependencies:
   rxdart: ^0.26.0
   shared_preferences: ^2.0.4
   get_it: ^6.0.0
-  flutter_statusbarcolor: ^0.2.3
-
+  flutter_statusbarcolor_ns: ^0.3.0-nullsafety
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
At the moment we can use a basic form using AppSkeletons that takes in text input and passes that to the viewmodel for submission. This should be updated to take in more than just the forms we have now. This will be done using the Forms functionality in stacked, and stacked might have to be updated to support more than just text as well.

- [x] Date Selection
- [x] Static dropdown list selection
- [x] large text form field