### PR TITLE
Add getter for currently selected theme

### DIFF
--- a/packages/stacked_themes/CHANGELOG.md
+++ b/packages/stacked_themes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Adds a `selectedThemeIndex` property to ThemeManager for getting currently enabled theme.
+
 ## 0.3.0
 
 - Updates the package to null-safety

--- a/packages/stacked_themes/README.md
+++ b/packages/stacked_themes/README.md
@@ -88,6 +88,14 @@ getThemeManager(context)
   .selectThemeAtIndex(1);
 ```
 
+You can get the currently selected theme index by using the `selectedThemeIndex` property of `ThemeManager`.
+
+```
+getThemeManager(context).selectedThemeIndex;
+```
+
+This will return the index of the currently enabled theme.
+
 ### Light and Dark
 
 If you only want to use Light and Dark themes then you can supply that to the `ThemeBuilder` instead of supplying multiple themes. When supplying Light and Dark themes you can also supply a defaultThemeMode, which is `ThemeMode.system` by default. When you leave it as `system` you're telling the `ThemeManager` that you want the system to determine if you're using light or dark mode. This is how you would supply your dark and light theme.

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -61,7 +61,7 @@ class ThemeManager {
   bool get isDarkMode => _selectedThemeMode == ThemeMode.dark;
 
   /// Get currently selected theme
-  int? get selectedTheme {
+  int? get selectedThemeIndex {
     if (themes != null && themes!.length > 1) {
       int? themeIndex = _sharedPreferences!.themeIndex;
       return themeIndex == null ? 0 : themeIndex;

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -60,6 +60,15 @@ class ThemeManager {
   /// Returns true if the ThemeMode is dark. This does not apply when you're using system as ThemeMode
   bool get isDarkMode => _selectedThemeMode == ThemeMode.dark;
 
+  /// Get currently selected theme
+  int? get selectedTheme {
+    if (themes != null && themes!.length > 1) {
+      int? themeIndex = _sharedPreferences!.themeIndex;
+      return themeIndex == null ? 0 : themeIndex;
+    }
+    return null;
+  }
+
   ThemeManager({
     this.themes,
     this.statusBarColorBuilder,

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 
 environment:


### PR DESCRIPTION
Add a getter to ThemeManager for getting the currently selected theme, when using multiple themes.

e.g.:

```dart
getThemeManager(context).selectedTheme
```

This seems to work for us, if it looks good to you I can add documentation, tests, etc.

fixes #284