### PR TITLE
Fixed a typo in the changelog

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.2
 
-- Made ViewModel variable naming scheme consistent. `ViewModel viewmodel` is now preferred.
+- Made ViewModel variable naming scheme consistent. `ViewModel viewModel` is now preferred.
 
 ## 2.0.1
 


### PR DESCRIPTION
Realized I made a typo in the changelog for the ViewModel variable name from #305 

Didn't capitalize `viewModel` correctly. 