### PR TITLE
This fixes issue #309

### DIFF
--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -54,6 +54,9 @@ class FirebaseAuthenticationService {
     return firebaseAuth.currentUser != null;
   }
 
+  /// Returns user data when a user has logged in or signed on this device
+  User? get getUser => firebaseAuth.currentUser;
+
   Future<FirebaseAuthenticationResult> signInWithGoogle() async {
     try {
       final GoogleSignInAccount? googleSignInAccount =


### PR DESCRIPTION
I think this line of code is no longer needed and should be removed in the future. Because all its functions can be done by the getUser

```
/// Returns the latest userToken stored in the Firebase Auth lib
  Future<String>? get userToken {
    return firebaseAuth.currentUser?.getIdToken();
  }

  /// Returns true when a user has logged in or signed on this device
  bool get hasUser {
    return firebaseAuth.currentUser != null;
  }

```
Note: this is my first commit so please verify before merge.