### PR TITLE
Changed get.off(page...) to get.off(()=>page....) for replaceWithTransition function

### DIFF
--- a/packages/stacked_services/lib/src/navigation_service.dart
+++ b/packages/stacked_services/lib/src/navigation_service.dart
@@ -120,7 +120,7 @@ class NavigationService {
       bool? popGesture,
       int? id}) {
     return Get.off(
-      page,
+      ()=>page,
       transition: _getTransitionOrDefault(transition),
       duration: duration ?? Get.defaultTransitionDuration,
       popGesture: popGesture ?? Get.isPopGestureEnable,


### PR DESCRIPTION
To guarantee the removal of the widget and its controllers from memory and also avoid the warning that occurs when replaceWithTransition is called upon.