### PR TITLE
build: update to latest version `4.1.3` 

### DIFF
--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
 
   # navigation
-  get: ^4.1.2
+  get: ^4.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Since the older version was having problem with Flutter web using `stacked` package

New update from getx where they make `Locale` null safe `Locale?`

https://github.com/jonataslaw/getx/commit/d6a8894d9dd24d065756dbccacbc919c260c5a7b