### PR TITLE
Use the default filter for the logger

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.4.7
+
+- Use the default filter for the logger
+
 ## 0.4.6
 
 - Added functionality to supply custom `locator` and `setupLocator` names.

--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -117,13 +117,6 @@ class MultipleLoggerOutput extends LogOutput {
   }
 }
 
-class LogAllTheTimeFilter extends LogFilter {
-  @override
-  bool shouldLog(LogEvent event) {
-    return true;
-  }
-}
-
 Logger $LogHelperNameKey(
   String className, {
   bool printCallingFunctionName = true,
@@ -132,7 +125,6 @@ Logger $LogHelperNameKey(
   String? showOnlyClass,
 }) {
   return Logger(
-    filter: LogAllTheTimeFilter(),
     printer: SimpleLogPrinter(
       className,
       printCallingFunctionName: printCallingFunctionName,

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.4.6
+version: 0.4.7
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
This is instead of using LogAllTheTimeFilter which always logged all levels and ignored the level variable in the Logger class.