### PR TITLE
Environment registration fix

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.6
 
-- `Environments` now will be automatically regiter which eleminated the need to call `registerEnvironment` manually if generated `setupLocator` wasn't used
+- `Environments` now will be automatically registered which eliminates the need to call `registerEnvironment` manually if generated `setupLocator` wasn't used
 
 ## 2.1.5
 

--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.6
+
+- `Environments` now will be automatically regiter which eleminated the need to call `registerEnvironment` manually if generated `setupLocator` wasn't used
+
 ## 2.1.5
 
 - Added functionality to supply custom `locator` and `setupLocator` names.

--- a/packages/stacked/README.md
+++ b/packages/stacked/README.md
@@ -1146,6 +1146,24 @@ final navigationService = locator<NavigationService>;
 
 To learn more about using get_it as a service locator you can [watch this video](https://youtu.be/vBT-FhgMaWM?t=321). That's all the functionality that the stacked_generator will generate for now. Over time we'll add more functionality that can help us reduce the amount of boilerplate required to build a stacked application.
 
+### Environments
+
+It is possible to register different dependencies for different environments by using `environments: {Environment.dev}` in the below example `NavigationService` is now only registered if we pass the environment name to `setupLocator(environment: Environment.dev);`
+
+```dart
+LazySingleton(
+    classType: NavigationService,
+    environments: {Environment.dev},
+ ),
+```
+
+Now passing your environment to `setupLocator` function will create a simple environment filter that will only validate dependencies that have no environments or one of their environments matches the given environment.
+Alternatively, you can pass your own EnvironmentFilter to decide what dependencies to register based on their environment keys, or use one of the shipped ones
+
+- NoEnvOrContainsAll
+- NoEnvOrContainsAny
+- SimpleEnvironmentFilter
+
 ### Logger
 
 If you want to add a Logger to your app, all you have to do is supply a logger config.

--- a/packages/stacked/lib/src/code_generation/stacked_locator.dart
+++ b/packages/stacked/lib/src/code_generation/stacked_locator.dart
@@ -10,7 +10,9 @@ class StackedLocator {
 
   EnvironmentFilter? _environmentFilter;
 
-  StackedLocator._(GetIt instance) : locator = instance;
+  StackedLocator._(GetIt instance) : locator = instance {
+    registerEnvironment();
+  }
 
   /// access to the Singleton instance of GetIt
   static StackedLocator get instance {
@@ -33,12 +35,13 @@ class StackedLocator {
   }) {
     assert(environmentFilter == null || environment == null);
     _environmentFilter = environmentFilter ?? NoEnvOrContains(environment);
-    if (!locator.isRegistered<Set<String?>>(instanceName: kEnvironmentsName)) {
-      locator.registerLazySingleton<Set<String?>>(
-        () => _environmentFilter!.environments,
-        instanceName: kEnvironmentsName,
-      );
-    }
+
+    removeRegistrationIfExists<Set<String?>>(instanceName: kEnvironmentsName);
+
+    locator.registerLazySingleton<Set<String?>>(
+      () => _environmentFilter!.environments,
+      instanceName: kEnvironmentsName,
+    );
   }
 
   bool _canRegister(Set<String>? registerFor) {
@@ -493,4 +496,10 @@ class StackedLocator {
   /// Or use async registrations methods or let individual instances signal their ready
   /// state on their own.
   void signalReady(Object instance) => locator.signalReady(instance);
+
+  void removeRegistrationIfExists<T extends Object>({String? instanceName}) {
+    if (locator.isRegistered<T>(instanceName: instanceName)) {
+      locator.unregister<T>(instanceName: instanceName);
+    }
+  }
 }

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -3,7 +3,7 @@ description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
 
-version: 2.1.5
+version: 2.1.6
 homepage: https://github.com/FilledStacks/stacked
 
 environment:


### PR DESCRIPTION
-  `Environments` now will be automatically registered which eliminates the need to call `registerEnvironment` manually if generated `setupLocator` wasn't used
- Updated docs 