### PR TITLE
Expose FirebaseAuth's authStateChange 

### DIFF
--- a/packages/stacked_firebase_auth/CHANGELOG.md
+++ b/packages/stacked_firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6
+
+- Expose authStateChanges from FirebaseAuth
+
 ## 0.2.5
 
 - Anonymous Login Added

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -61,6 +61,11 @@ class FirebaseAuthenticationService {
     return firebaseAuth.currentUser != null;
   }
 
+  /// Exposes the authStateChanges functionality.
+  Stream<User?> get authStateChanges {
+    return firebaseAuth.authStateChanges();
+  }
+
   /// Returns `true` when email has a user registered
   Future<bool> emailExists(String email) async {
     try {

--- a/packages/stacked_firebase_auth/pubspec.yaml
+++ b/packages/stacked_firebase_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
-version: 0.2.4
+version: 0.2.6
 homepage: https://github.com/FilledStacks/stacked
 
 environment:


### PR DESCRIPTION
To mock out authStateChanges() for unit testing, it would be useful to expose it through the stacked FirebaseAuthenticationService. Please, Let me know if that makes sense. Thanks!
