### PR TITLE
Adds generic type to pass in and deprecated `responseData` property

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.8
+
+- Added generic type arguments for `OverlayResponse` and `OverlayRequest` for dialogs and bottom sheets
+- Deprecated `responseData` and added new property `data` that corresponds to that type provided
+
 ## 0.8.7
 
 - Added `currentArguments` in NavigationService

--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Added generic type arguments for `OverlayResponse` and `OverlayRequest` for dialogs and bottom sheets
 - Deprecated `responseData` and added new property `data` that corresponds to that type provided
+- Added 2 generic type arguments for `showCustomDialog` and `showCustomSheet` 
+- The first generic type argument for `showCustomDialog` from `DialogService` is intended for the response `data` and the second generic type argument for `showCustomSheet` from `BottomSheetService` is intended for the request payload `data`
 
 ## 0.8.7
 

--- a/packages/stacked_services/example/lib/enums/bottomsheet_type.dart
+++ b/packages/stacked_services/example/lib/enums/bottomsheet_type.dart
@@ -2,4 +2,5 @@ enum BottomSheetType {
   FloatingBox,
   ScrollableList,
   ImageSheet,
+  Generic,
 }

--- a/packages/stacked_services/example/lib/enums/dialog_type.dart
+++ b/packages/stacked_services/example/lib/enums/dialog_type.dart
@@ -1,3 +1,4 @@
 enum DialogType {
   Basic,
+  Generic,
 }

--- a/packages/stacked_services/example/lib/ui/setup_bottom_sheet_ui.dart
+++ b/packages/stacked_services/example/lib/ui/setup_bottom_sheet_ui.dart
@@ -8,7 +8,19 @@ void setupBottomSheetUi() {
 
   final builders = {
     BottomSheetType.FloatingBox: (context, sheetRequest, completer) =>
-        _FloatingBoxBottomSheet(request: sheetRequest, completer: completer)
+        _FloatingBoxBottomSheet(
+          request: sheetRequest,
+          completer: completer,
+        ),
+    BottomSheetType.Generic: (
+      context,
+      sheetRequest,
+      Function(SheetResponse<GenericBottomSheetResponse>) completer,
+    ) =>
+        GenericBottomSheet(
+          request: sheetRequest,
+          completer: completer,
+        ),
   };
 
   bottomSheetService.setCustomSheetBuilders(builders);
@@ -61,6 +73,94 @@ class _FloatingBoxBottomSheet extends StatelessWidget {
               ),
               TextButton(
                 onPressed: () => completer(SheetResponse(confirmed: true)),
+                child: Text(
+                  request.mainButtonTitle,
+                  style: TextStyle(color: Colors.white),
+                ),
+                style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all<Color>(
+                    Theme.of(context).primaryColor,
+                  ),
+                ),
+              )
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class GenericBottomSheetRequest {
+  const GenericBottomSheetRequest({
+    this.message = 'GenericBottomSheetRequest',
+  });
+
+  final String message;
+}
+
+class GenericBottomSheetResponse {
+  const GenericBottomSheetResponse({
+    this.message = 'GenericBottomSheetResponse',
+  });
+
+  final String message;
+}
+
+class GenericBottomSheet extends StatelessWidget {
+  final SheetRequest request;
+  final Function(SheetResponse<GenericBottomSheetResponse>) completer;
+
+  const GenericBottomSheet({
+    Key key,
+    this.request,
+    this.completer,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.all(25),
+      padding: EdgeInsets.all(25),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            request.title ?? 'Generic Bottom Sheet',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: Colors.grey[900],
+            ),
+          ),
+          SizedBox(height: 10),
+          Text(
+            request.description,
+            style: TextStyle(color: Colors.grey),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              MaterialButton(
+                onPressed: () => completer(SheetResponse(
+                  confirmed: true,
+                  data: GenericBottomSheetResponse(message: 'SecondaryButton'),
+                )),
+                child: Text(
+                  request.secondaryButtonTitle,
+                  style: TextStyle(color: Theme.of(context).primaryColor),
+                ),
+              ),
+              TextButton(
+                onPressed: () => completer(SheetResponse(
+                  confirmed: true,
+                  data: GenericBottomSheetResponse(message: 'MainButton'),
+                )),
                 child: Text(
                   request.mainButtonTitle,
                   style: TextStyle(color: Colors.white),

--- a/packages/stacked_services/example/lib/ui/setup_dialog_ui.dart
+++ b/packages/stacked_services/example/lib/ui/setup_dialog_ui.dart
@@ -8,7 +8,13 @@ void setupDialogUi() {
 
   final builders = {
     DialogType.Basic: (context, sheetRequest, completer) =>
-        _BasicDialog(request: sheetRequest, completer: completer)
+        _BasicDialog(request: sheetRequest, completer: completer),
+    DialogType.Generic: (context, sheetRequest,
+            Function(DialogResponse<GenericDialogResponse>) completer) =>
+        _GenericDialog(
+          request: sheetRequest,
+          completer: completer,
+        ),
   };
 
   dialogService.registerCustomDialogBuilders(builders);
@@ -51,6 +57,86 @@ class _BasicDialog extends StatelessWidget {
             ),
             GestureDetector(
               onTap: () => completer(DialogResponse()),
+              child: Container(
+                child: request.showIconInMainButton
+                    ? Icon(Icons.check_circle)
+                    : Text(request.mainButtonTitle),
+                alignment: Alignment.center,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.redAccent,
+                  borderRadius: BorderRadius.circular(5),
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class GenericDialogRequest {
+  const GenericDialogRequest({
+    this.message = 'Hello World',
+  });
+
+  final String message;
+}
+
+class GenericDialogResponse {
+  const GenericDialogResponse({
+    this.message = 'Hello World',
+  });
+
+  final String message;
+}
+
+class _GenericDialog extends StatelessWidget {
+  final DialogRequest request;
+  final Function(DialogResponse<GenericDialogResponse>) completer;
+
+  const _GenericDialog({
+    Key key,
+    this.request,
+    this.completer,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              request.title ?? 'Generic Dialog',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 23),
+            ),
+            SizedBox(
+              height: 10,
+            ),
+            Text(
+              request.description,
+              style: TextStyle(
+                fontSize: 18,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(
+              height: 20,
+            ),
+            GestureDetector(
+              onTap: () => completer(
+                DialogResponse(data: GenericDialogResponse()),
+              ),
               child: Container(
                 child: request.showIconInMainButton
                     ? Icon(Icons.check_circle)

--- a/packages/stacked_services/example/lib/ui/views/bottom_sheet_view.dart
+++ b/packages/stacked_services/example/lib/ui/views/bottom_sheet_view.dart
@@ -3,6 +3,8 @@ import 'package:example/enums/bottomsheet_type.dart';
 import 'package:flutter/material.dart';
 import 'package:stacked_services/stacked_services.dart';
 
+import '../setup_bottom_sheet_ui.dart';
+
 class BottomSheetView extends StatelessWidget {
   BottomSheetView({Key key}) : super(key: key);
 
@@ -82,6 +84,33 @@ class BottomSheetView extends StatelessWidget {
             },
             child: Text(
               'Show Custom Bottom Sheet',
+            ),
+          ),
+          Text(
+            'Press the button below to show one of the generic custom sheets',
+            softWrap: true,
+            style: TextStyle(
+              fontSize: 14,
+            ),
+          ),
+          OutlinedButton(
+            onPressed: () async {
+              final response = await _bottomSheetService.showCustomSheet<
+                  GenericBottomSheetResponse, GenericBottomSheetRequest>(
+                variant: BottomSheetType.Generic,
+                title: 'This is a generic bottom sheet',
+                description:
+                    'This sheet is a custom built bottom sheet UI that allows you to show it from any service or viewmodel.',
+                mainButtonTitle: 'Awesome!',
+                secondaryButtonTitle: 'This is cool',
+              );
+
+              print('confirmationResponse confirmed: ${response?.confirmed}');
+
+              print('response ${response.data.message}');
+            },
+            child: Text(
+              'Show Generic Custom Bottom Sheet',
             ),
           ),
         ],

--- a/packages/stacked_services/example/lib/ui/views/dialog_view.dart
+++ b/packages/stacked_services/example/lib/ui/views/dialog_view.dart
@@ -1,4 +1,5 @@
 import 'package:example/app/locator.dart';
+import 'package:example/ui/setup_dialog_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:stacked_services/stacked_services.dart';
 
@@ -97,6 +98,34 @@ class DialogView extends StatelessWidget {
                 },
                 child: Text(
                   'Show Custom Text Dialog',
+                ),
+              ),
+              Text(
+                'Press the button below to show a Custom Generic dialog',
+                softWrap: true,
+                style: TextStyle(
+                  fontSize: 14,
+                ),
+              ),
+              OutlinedButton(
+                onPressed: () async {
+                  final response = await _dialogService.showCustomDialog<
+                      GenericDialogResponse, GenericDialogRequest>(
+                    variant: DialogType.Generic,
+                    title:
+                        'This is a custom Generic UI with Text as main button',
+                    description:
+                        'Sheck out the builder in the dialog_ui_register.dart file',
+                    mainButtonTitle: 'Ok',
+                    showIconInMainButton: false,
+                    barrierDismissible: true,
+                    data: GenericDialogRequest(),
+                  );
+
+                  print(response.data.message);
+                },
+                child: Text(
+                  'Show Generic Dialog',
                 ),
               ),
               OutlinedButton(

--- a/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -58,8 +58,19 @@ class BottomSheetService {
     );
   }
 
-  // Creates a popup with the given widget, a scale animation, and faded background.
-  Future<SheetResponse<T>?> showCustomSheet<T>({
+  /// Creates a popup with the given widget, a scale animation, and faded background.
+  ///
+  /// The first generic type argument will be the [BottomSheetResponse]
+  /// while the second generic type argument is the [BottomSheetRequest]
+  ///
+  /// e.g.
+  /// ```dart
+  /// await _bottomSheetService.showCustomSheet<GenericBottomSheetResponse, GenericBottomSheetRequest>();
+  /// ```
+  ///
+  /// Where [GenericBottomSheetResponse] is a defined model response,
+  /// and [GenericBottomSheetRequest] is the request model.
+  Future<SheetResponse<T>?> showCustomSheet<T, R>({
     dynamic variant,
     String? title,
     String? description,
@@ -77,7 +88,7 @@ class BottomSheetService {
     bool isScrollControlled = false,
     String barrierLabel = '',
     @Deprecated('Use `data` and pass in a generic type.') dynamic customData,
-    T? data,
+    R? data,
     bool enableDrag = true,
     Duration? exitBottomSheetDuration,
     Duration? enterBottomSheetDuration,
@@ -101,7 +112,7 @@ class BottomSheetService {
         type: MaterialType.transparency,
         child: sheetBuilder!(
           Get.context!,
-          SheetRequest(
+          SheetRequest<R>(
             title: title,
             description: description,
             hasImage: hasImage,

--- a/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -59,7 +59,7 @@ class BottomSheetService {
   }
 
   // Creates a popup with the given widget, a scale animation, and faded background.
-  Future<SheetResponse?> showCustomSheet({
+  Future<SheetResponse<T>?> showCustomSheet<T>({
     dynamic variant,
     String? title,
     String? description,
@@ -76,7 +76,8 @@ class BottomSheetService {
     bool barrierDismissible = true,
     bool isScrollControlled = false,
     String barrierLabel = '',
-    dynamic customData,
+    @Deprecated('Use `data` and pass in a generic type.') dynamic customData,
+    T? data,
     bool enableDrag = true,
     Duration? exitBottomSheetDuration,
     Duration? enterBottomSheetDuration,
@@ -95,7 +96,7 @@ class BottomSheetService {
 
     final sheetBuilder = _sheetBuilders![variant];
 
-    return Get.bottomSheet<SheetResponse>(
+    return Get.bottomSheet<SheetResponse<T>>(
       Material(
         type: MaterialType.transparency,
         child: sheetBuilder!(
@@ -114,6 +115,7 @@ class BottomSheetService {
             takesInput: takesInput,
             customData: customData,
             variant: variant,
+            data: data,
           ),
           completeSheet,
         ),

--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -152,8 +152,19 @@ class DialogService {
     );
   }
 
-  // Creates a popup with the given widget, a scale animation, and faded background.
-  Future<DialogResponse<T>?> showCustomDialog<T>({
+  /// Creates a popup with the given widget, a scale animation, and faded background.
+  ///
+  /// The first generic type argument will be the [DialogResponse]
+  /// while the second generic type argument is the [DialogRequest]
+  ///
+  /// e.g.
+  /// ```dart
+  /// await _dialogService.showCustomDialog<GenericDialogResponse, GenericDialogRequest>();
+  /// ```
+  ///
+  /// Where [GenericDialogResponse] is a defined model response,
+  /// and [GenericDialogRequest] is the request model.
+  Future<DialogResponse<T>?> showCustomDialog<T, R>({
     dynamic variant,
     String? title,
     String? description,
@@ -171,7 +182,7 @@ class DialogService {
     String barrierLabel = '',
     @Deprecated('Prefer to use `data` and pass in a generic type.')
         dynamic customData,
-    T? data,
+    R? data,
   }) {
     assert(
       _dialogBuilders != null,
@@ -196,7 +207,7 @@ class DialogService {
         child: Builder(
           builder: (BuildContext context) => customDialogUI!(
             context,
-            DialogRequest(
+            DialogRequest<R>(
               title: title,
               description: description,
               hasImage: hasImage,

--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -153,7 +153,7 @@ class DialogService {
   }
 
   // Creates a popup with the given widget, a scale animation, and faded background.
-  Future<DialogResponse?> showCustomDialog({
+  Future<DialogResponse<T>?> showCustomDialog<T>({
     dynamic variant,
     String? title,
     String? description,
@@ -169,7 +169,9 @@ class DialogService {
     Color barrierColor = Colors.black54,
     bool barrierDismissible = false,
     String barrierLabel = '',
-    dynamic customData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        dynamic customData,
+    T? data,
   }) {
     assert(
       _dialogBuilders != null,
@@ -183,7 +185,7 @@ class DialogService {
       'You have to call registerCustomDialogBuilder to use this function. Look at the custom dialog UI section in the stacked_services readme.',
     );
 
-    return Get.generalDialog<DialogResponse>(
+    return Get.generalDialog<DialogResponse<T>>(
       barrierColor: barrierColor,
       transitionDuration: const Duration(milliseconds: 200),
       barrierDismissible: barrierDismissible,
@@ -207,6 +209,7 @@ class DialogService {
               additionalButtonTitle: additionalButtonTitle,
               takesInput: takesInput,
               customData: customData,
+              data: data,
               variant: variant,
             ),
             completeDialog,

--- a/packages/stacked_services/lib/src/models/overlay_request.dart
+++ b/packages/stacked_services/lib/src/models/overlay_request.dart
@@ -1,4 +1,4 @@
-class OverlayRequest {
+class OverlayRequest<T> {
   /// The title for the dialog
   final String? title;
 
@@ -37,7 +37,11 @@ class OverlayRequest {
   final dynamic variant;
 
   /// Extra data to be passed to the UI
+  @Deprecated('Use `data` and pass in a generic type.')
   final dynamic customData;
+
+  /// Extra data to be passed to the UI
+  final T? data;
 
   OverlayRequest({
     this.showIconInMainButton,
@@ -52,11 +56,12 @@ class OverlayRequest {
     this.additionalButtonTitle,
     this.takesInput,
     this.customData,
+    this.data,
     this.variant,
   });
 }
 
-class DialogRequest extends OverlayRequest {
+class DialogRequest<T> extends OverlayRequest<T> {
   DialogRequest({
     bool? showIconInMainButton,
     bool? showIconInSecondaryButton,
@@ -70,6 +75,7 @@ class DialogRequest extends OverlayRequest {
     String? additionalButtonTitle,
     bool? takesInput,
     dynamic customData,
+    T? data,
     dynamic variant,
   }) : super(
           additionalButtonTitle: additionalButtonTitle,
@@ -84,11 +90,12 @@ class DialogRequest extends OverlayRequest {
           showIconInSecondaryButton: showIconInSecondaryButton,
           takesInput: takesInput,
           title: title,
+          data: data,
           variant: variant,
         );
 }
 
-class SheetRequest extends OverlayRequest {
+class SheetRequest<T> extends OverlayRequest<T> {
   SheetRequest({
     bool? showIconInMainButton,
     bool? showIconInSecondaryButton,
@@ -102,6 +109,7 @@ class SheetRequest extends OverlayRequest {
     String? additionalButtonTitle,
     bool? takesInput,
     dynamic customData,
+    T? data,
     dynamic variant,
   }) : super(
           additionalButtonTitle: additionalButtonTitle,
@@ -117,5 +125,6 @@ class SheetRequest extends OverlayRequest {
           takesInput: takesInput,
           title: title,
           variant: variant,
+          data: data,
         );
 }

--- a/packages/stacked_services/lib/src/models/overlay_request.dart
+++ b/packages/stacked_services/lib/src/models/overlay_request.dart
@@ -37,7 +37,6 @@ class OverlayRequest<T> {
   final dynamic variant;
 
   /// Extra data to be passed to the UI
-  @Deprecated('Use `data` and pass in a generic type.')
   final dynamic customData;
 
   /// Extra data to be passed to the UI
@@ -55,7 +54,8 @@ class OverlayRequest<T> {
     this.secondaryButtonTitle,
     this.additionalButtonTitle,
     this.takesInput,
-    this.customData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        this.customData,
     this.data,
     this.variant,
   });
@@ -74,7 +74,8 @@ class DialogRequest<T> extends OverlayRequest<T> {
     String? secondaryButtonTitle,
     String? additionalButtonTitle,
     bool? takesInput,
-    dynamic customData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        dynamic customData,
     T? data,
     dynamic variant,
   }) : super(
@@ -108,7 +109,8 @@ class SheetRequest<T> extends OverlayRequest<T> {
     String? secondaryButtonTitle,
     String? additionalButtonTitle,
     bool? takesInput,
-    dynamic customData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        dynamic customData,
     T? data,
     dynamic variant,
   }) : super(

--- a/packages/stacked_services/lib/src/models/overlay_response.dart
+++ b/packages/stacked_services/lib/src/models/overlay_response.dart
@@ -5,7 +5,6 @@ class OverlayResponse<T> {
 
   /// A place to put any response data from dialogs that may contain text fields
   /// or multi selection options
-  @Deprecated('Use `data` and pass in a generic type.')
   final dynamic responseData;
 
   /// A place to put any response data from dialogs that may contain text fields
@@ -14,7 +13,8 @@ class OverlayResponse<T> {
 
   OverlayResponse({
     this.confirmed = false,
-    this.responseData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        this.responseData,
     this.data,
   });
 }
@@ -23,7 +23,8 @@ class OverlayResponse<T> {
 class DialogResponse<T> extends OverlayResponse<T> {
   DialogResponse({
     bool confirmed = false,
-    dynamic responseData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        dynamic responseData,
     T? data,
   }) : super(
           confirmed: confirmed,
@@ -36,7 +37,8 @@ class DialogResponse<T> extends OverlayResponse<T> {
 class SheetResponse<T> extends OverlayResponse<T> {
   SheetResponse({
     bool confirmed = false,
-    dynamic responseData,
+    @Deprecated('Prefer to use `data` and pass in a generic type.')
+        dynamic responseData,
     T? data,
   }) : super(
           confirmed: confirmed,

--- a/packages/stacked_services/lib/src/models/overlay_response.dart
+++ b/packages/stacked_services/lib/src/models/overlay_response.dart
@@ -1,36 +1,46 @@
-class OverlayResponse {
+class OverlayResponse<T> {
   /// Indicates if a show confirmation call has been confirmed or rejected.
   /// null will be returned when it's not a confirmation dialog.
   final bool confirmed;
 
   /// A place to put any response data from dialogs that may contain text fields
   /// or multi selection options
+  @Deprecated('Use `data` and pass in a generic type.')
   final dynamic responseData;
+
+  /// A place to put any response data from dialogs that may contain text fields
+  /// or multi selection options
+  final T? data;
 
   OverlayResponse({
     this.confirmed = false,
     this.responseData,
+    this.data,
   });
 }
 
 /// The response returned from awaiting a call on the [DialogService]
-class DialogResponse extends OverlayResponse {
+class DialogResponse<T> extends OverlayResponse<T> {
   DialogResponse({
     bool confirmed = false,
     dynamic responseData,
+    T? data,
   }) : super(
           confirmed: confirmed,
           responseData: responseData,
+          data: data,
         );
 }
 
 /// The response returned from awaiting a call on the [BottomSheetService]
-class SheetResponse extends OverlayResponse {
+class SheetResponse<T> extends OverlayResponse<T> {
   SheetResponse({
     bool confirmed = false,
     dynamic responseData,
+    T? data,
   }) : super(
           confirmed: confirmed,
           responseData: responseData,
+          data: data,
         );
 }

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.8.7
+version: 0.8.8
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:


### PR DESCRIPTION
Typically when we register these in `setup_dialog_ui` or `setup_bottom_sheet_ui` we put up an alias on what we want to have a type for property `customData`, so instead of that we can have a generic type argument

For example usage, we can have something like:

```dart
void setupDialogUi() {
  final dialogService = locator<DialogService>();

  final builders = {
    DialogType.basic: (context, sheetRequest, SheetResponse<BasicDialogResponse> completer) =>
        _BasicDialog(request: sheetRequest, completer: completer),
    DialogType.form:  (context, sheetRequest, SheetResponse<FormDialogResponse> completer) =>
        _FormDialog(request: sheetRequest, completer: completer),
  };

  dialogService.registerCustomDialogBuilders(builders);
}
```

But I am not sure if this is going to work, was not able to try it out myself yet