### PR TITLE
This fixed issue #411

### DIFF
--- a/packages/stacked/example/lib/app/app.router.dart
+++ b/packages/stacked/example/lib/app/app.router.dart
@@ -49,8 +49,14 @@ class StackedRouter extends RouterBase {
   Map<Type, StackedRouteFactory> get pagesMap => _pagesMap;
   final _pagesMap = <Type, StackedRouteFactory>{
     HomeView: (data) {
+      var args = data.getArgs<HomeViewArguments>(
+        orElse: () => HomeViewArguments(),
+      );
       return MaterialPageRoute<dynamic>(
-        builder: (context) => const HomeView(),
+        builder: (context) => HomeView(
+          key: args.key,
+          defaultValue: args.defaultValue,
+        ),
         settings: data,
       );
     },
@@ -99,6 +105,13 @@ class StackedRouter extends RouterBase {
 /// ************************************************************************
 /// Arguments holder classes
 /// *************************************************************************
+
+/// HomeView arguments holder class
+class HomeViewArguments {
+  final Key? key;
+  final String defaultValue;
+  HomeViewArguments({this.key, this.defaultValue = "Default"});
+}
 
 /// DetailsView arguments holder class
 class DetailsViewArguments {

--- a/packages/stacked/example/lib/ui/home/home_view.dart
+++ b/packages/stacked/example/lib/ui/home/home_view.dart
@@ -7,7 +7,9 @@ import '../startup/startup_view.dart';
 import 'home_viewmodel.dart';
 
 class HomeView extends StatelessWidget {
-  const HomeView({Key? key}) : super(key: key);
+  const HomeView({Key? key, this.defaultValue = "Default"}) : super(key: key);
+
+  final String defaultValue;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 0.4.9
+
+- Fixes Default parameter value generation bug on stacked router
+  [issue #411](https://github.com/FilledStacks/stacked/issues/411)
+
 ## 0.4.8
 
 - Added ability to pass custom logger outputs to MultiLoggerOutput

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   build: ^2.0.0
   source_gen: ^1.0.0
-  analyzer: ^1.3.0
+  analyzer: 1.5.0
   path: ^1.6.4
   # logger: ^1.0.0
   recase: ^4.0.0-nullsafety.0

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.4.8
+version: 0.4.9
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
- Locked `analyzer` version to `1.5.0`
- This fixed issue #411 