### PR TITLE
This fixes issues #426

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- Replaced `dart:io` with `universal_io`
+
 ## 2.1.9
 
 - Added ability to pass custom logger outputs to MultiLoggerOutput

--- a/packages/stacked/lib/src/code_generation/router/router_utils.dart
+++ b/packages/stacked/lib/src/code_generation/router/router_utils.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -3,7 +3,7 @@ description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
 
-version: 2.1.9
+version: 2.2.1
 homepage: https://github.com/FilledStacks/stacked
 
 environment:
@@ -16,6 +16,9 @@ dependencies:
   meta: ^1.3.0
   provider: ^5.0.0
   collection: ^1.15.0
+
+  #universal_io
+  universal_io: ^2.0.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_themes/CHANGELOG.md
+++ b/packages/stacked_themes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+
+- Replaced `dart:io` with `universal_io`
+
 ## 0.3.5
 
 - Fixed `PlatformService` registration issue

--- a/packages/stacked_themes/lib/src/services/platform_service.dart
+++ b/packages/stacked_themes/lib/src/services/platform_service.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 /// An abstraction over the Platform information so that we can have pure unit tests
 class PlatformService {

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
-version: 0.3.5
+version: 0.3.6
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 
 environment:
@@ -15,6 +15,10 @@ dependencies:
   shared_preferences: ^2.0.6
   get_it: ^7.1.3
   flutter_statusbarcolor_ns: ^0.3.0-nullsafety
+
+  #universal_io 
+  universal_io: ^2.0.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
- This fixes issues #426
- Replaced `dart:io` with `universal_io` in `stacked`
- Replaced `dart:io` with `universal_io` in `stacked_themes`