### PR TITLE
[stacked_services] Pass down ignoreSafeArea to Get.bottomSheet

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.11
+
+- Add `ignoreSafeArea` parameter to `showBottomSheet` and `showCustomSheet`, pass down to `get` bottomSheet method
+
 ## 0.8.10
 
 - Pass down generic types to `NavigationService` methods along with the properties relevant to `get` router

--- a/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -28,6 +28,7 @@ class BottomSheetService {
     bool isScrollControlled = false,
     Duration? exitBottomSheetDuration,
     Duration? enterBottomSheetDuration,
+    bool? ignoreSafeArea,
   }) {
     return Get.bottomSheet<SheetResponse?>(
       Material(
@@ -55,6 +56,7 @@ class BottomSheetService {
       enableDrag: barrierDismissible && enableDrag,
       exitBottomSheetDuration: exitBottomSheetDuration,
       enterBottomSheetDuration: enterBottomSheetDuration,
+      ignoreSafeArea: ignoreSafeArea,
     );
   }
 
@@ -92,6 +94,7 @@ class BottomSheetService {
     bool enableDrag = true,
     Duration? exitBottomSheetDuration,
     Duration? enterBottomSheetDuration,
+    bool? ignoreSafeArea,
   }) {
     assert(
       _sheetBuilders != null,
@@ -136,6 +139,7 @@ class BottomSheetService {
       enableDrag: barrierDismissible && enableDrag,
       exitBottomSheetDuration: exitBottomSheetDuration,
       enterBottomSheetDuration: enterBottomSheetDuration,
+      ignoreSafeArea: ignoreSafeArea,
     );
   }
 

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.8.10
+version: 0.8.11
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:


### PR DESCRIPTION
We ran into the issue https://github.com/flutter/flutter/issues/59204 where bottom sheets with `isScrollControlled: true` do not respect SafeArea.

getx has a solution https://github.com/jonataslaw/getx/issues/44

So this change just allows us to pass down `ignoreSafeArea` to the Get.bottomSheet method, which solves our problem with SafeArea.

I'm not sure why you wouldn't want `ignoreSafeArea` to be false all of the time, but either way this does not change existing behavior in case there are implications.