### PR TITLE
get.generalDialog parameter useRootNavigator

### DIFF
--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -201,7 +201,6 @@ class DialogService {
       transitionDuration: const Duration(milliseconds: 200),
       barrierDismissible: barrierDismissible,
       barrierLabel: barrierLabel,
-      useRootNavigator: true,
       pageBuilder: (BuildContext buildContext, _, __) => SafeArea(
         key: Key('dialog_view'),
         child: Builder(


### PR DESCRIPTION
The get package removed the argument useRootNavigator from the get.generalDialog. This causes the following error:

```
./../snap/flutter/common/flutter/.pub-cache/hosted/pub.dartlang.org/stacked_services-0.8.11/
lib/src/dialog/dialog_service.dart:204:7: Error: No named parameter with the name
'useRootNavigator'.
      useRootNavigator: true,
```

Didn't double check the consequences of deleting so that should be done, sorry about that.