### PR TITLE
Update stacked_generator to use analyzer 2.0

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 0.5.2
+
+- Update analyzer dependency to `analyzer: ^2.0` (you can upgrade json_serialization to 5.0 without dependency conflicts)
+
 ## 0.5.1
 
 - Added ability to pass parameter to factories with `FactoryWithParam`

--- a/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
@@ -90,7 +90,6 @@ class RouteConfigResolver {
       }
     });
 
-    // final returnType = stackedRoute.objectValue.type?.typeArguments.first;
     final returnType = stackedRoute.objectValue.type;
     routeConfig.returnType =
         returnType!.getDisplayString(withNullability: true);

--- a/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
@@ -90,8 +90,10 @@ class RouteConfigResolver {
       }
     });
 
-    final returnType = stackedRoute.objectValue.type?.typeArguments.first;
-    routeConfig.returnType = toDisplayString(returnType!);
+    // final returnType = stackedRoute.objectValue.type?.typeArguments.first;
+    final returnType = stackedRoute.objectValue.type;
+    routeConfig.returnType =
+        returnType!.getDisplayString(withNullability: true);
 
     if (routeConfig.returnType != 'dynamic') {
       routeConfig.imports.addAll(_importResolver.resolveAll(returnType));

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -12,15 +12,15 @@ dependencies:
 
   build: ^2.0.0
   source_gen: ^1.0.0
-  analyzer: 1.5.0
+  analyzer: ^2.0.0
   path: ^1.6.4
   # logger: ^1.0.0
   recase: ^4.0.0-nullsafety.0
   stacked:
-    ^2.2.1
-    # path: ../stacked
+    # ^2.2.1
+    path: ../stacked
 
 dev_dependencies:
-  build_runner: ^1.11.5
+  build_runner: ^2.0.6
   source_gen_test: ^1.0.0
   test:

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   # logger: ^1.0.0
   recase: ^4.0.0-nullsafety.0
   stacked:
-    # ^2.2.1
-    path: ../stacked
+    ^2.2.1
+    # path: ../stacked
 
 dev_dependencies:
   build_runner: ^2.0.6


### PR DESCRIPTION
This enables us to use json_serialization: ^5.0 without dependency conflicts.