### PR TITLE
Fix navigation pop return type error.

### DIFF
--- a/packages/stacked_generator/lib/src/generators/router/router_class_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/router/router_class_generator.dart
@@ -266,6 +266,17 @@ class RouterClassGenerator extends BaseGenerator {
   }
 
   void _generateRouteBuilder(RouteConfig r, String constructor) {
+    if (r.returnType != null && r.returnType!.contains('<')) {
+      if (r.returnType!.contains('CustomRoute') ||
+          r.returnType!.contains('MaterialRoute') ||
+          r.returnType!.contains('CupertinoRoute') ||
+          r.returnType!.contains('AdaptiveRoute')) {
+        // get the correct return type
+        final type = r.returnType!.substring(
+            r.returnType!.indexOf('<') + 1, r.returnType!.indexOf('>'));
+        r.returnType = type;
+      }
+    }
     final returnType = r.returnType ?? 'dynamic';
     if (r.routeType == RouteType.cupertino) {
       write(


### PR DESCRIPTION
The following _TypeError was thrown while handling a gesture:
type 'RETURNOBJECT' is not a subtype of type 'CustomRoute<dynamic>?' of 'result'

This error occur when you want to pop and return object 