### PR TITLE
Feature/deprecated warning

### DIFF
--- a/packages/stacked_themes/CHANGELOG.md
+++ b/packages/stacked_themes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.7
+
+- Fixed `flutter_statusbarcolor_ns` deprecated Android embedding warning
+
 ## 0.3.6
 
 - Replaced `dart:io` with `universal_io`

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -2,6 +2,7 @@ name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
 version: 0.3.6
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +15,10 @@ dependencies:
   rxdart: ^0.27.1
   shared_preferences: ^2.0.6
   get_it: ^7.1.3
-  flutter_statusbarcolor_ns: ^0.3.0-nullsafety
+  flutter_statusbarcolor_ns:
+    git:
+      url: https://github.com/hurbes/flutter_statusbarcolor.git
+      ref: feature/android-embedding-v2
 
   #universal_io 
   universal_io: ^2.0.4

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
-version: 0.3.6
+version: 0.3.7
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 publish_to: none
 


### PR DESCRIPTION
- Fixed `flutter_statusbarcolor_ns` deprecated Android embedding warning
- Forked  `flutter_statusbarcolor_ns` package and updated implementation with new Android embedding v2 API with recommended package implementation guide using `FlutterPlugin` and `ActivityAware` classes

This fixes issue #501
