### PR TITLE
Stacked Themes

### DIFF
--- a/packages/stacked_themes/CHANGELOG.md
+++ b/packages/stacked_themes/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.7
+## 0.3.8
 
 - Adds `navigationBarColorBuilder` to change navigation bar color
 

--- a/packages/stacked_themes/CHANGELOG.md
+++ b/packages/stacked_themes/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.3.7
 
+- Adds `navigationBarColorBuilder` to change navigation bar color
+
+## 0.3.7
+
 - Fixed `flutter_statusbarcolor_ns` deprecated Android embedding warning
 
 ## 0.3.6

--- a/packages/stacked_themes/example/lib/main.dart
+++ b/packages/stacked_themes/example/lib/main.dart
@@ -28,6 +28,7 @@ class MyApp extends StatelessWidget {
         accentColor: Colors.yellow[300],
       ),
       statusBarColorBuilder: (theme) => theme.accentColor,
+      navigationBarColorBuilder: (theme) => theme.accentColor,
       themes: getThemes(),
       builder: (context, regularTheme, darkTheme, themeMode) => MaterialApp(
         title: 'Flutter Demo',

--- a/packages/stacked_themes/example/lib/main.dart
+++ b/packages/stacked_themes/example/lib/main.dart
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
       ),
       statusBarColorBuilder: (theme) => theme.accentColor,
       navigationBarColorBuilder: (theme) => theme.accentColor,
-      themes: getThemes(),
+      // themes: getThemes(),
       builder: (context, regularTheme, darkTheme, themeMode) => MaterialApp(
         title: 'Flutter Demo',
         theme: regularTheme,

--- a/packages/stacked_themes/lib/src/services/statusbar_service.dart
+++ b/packages/stacked_themes/lib/src/services/statusbar_service.dart
@@ -15,4 +15,16 @@ class StatusBarService {
       FlutterStatusbarcolor.setStatusBarWhiteForeground(false);
     }
   }
+
+  Future? updateNavigationBarColor(Color navigationBarColor) async {
+    // Set navigation bar color
+    await FlutterStatusbarcolor.setNavigationBarColor(navigationBarColor);
+
+    // Check the constrast between the colors and set the navigation bar icons colors to white or dark
+    if (useWhiteForeground(navigationBarColor)) {
+      FlutterStatusbarcolor.setNavigationBarWhiteForeground(true);
+    } else {
+      FlutterStatusbarcolor.setNavigationBarWhiteForeground(false);
+    }
+  }
 }

--- a/packages/stacked_themes/lib/src/theme_builder.dart
+++ b/packages/stacked_themes/lib/src/theme_builder.dart
@@ -113,11 +113,15 @@ class _ThemeBuilderState extends State<ThemeBuilder>
   //NOTE: re-apply the appropriate theme when the application gets back into the foreground
   void adjustSystemThemeIfNecessary() {
     switch (themeManager.selectedThemeMode) {
-      //do nothing
+      // When app becomes inactive the overlay colors might change.
+      // Therefore when the app is resumed we also need to update
+      // overlay colors back to their original state. In case
+      // selected theme mode is system the overlay colors will be
+      // automatically updated.
       case ThemeMode.light:
-        break;
-      //do nothing
       case ThemeMode.dark:
+        final selectedTheme = themeManager.getSelectedTheme().selectedTheme;
+        themeManager.updateOverlayColors(selectedTheme);
         break;
       //reapply theme
       case ThemeMode.system:

--- a/packages/stacked_themes/lib/src/theme_builder.dart
+++ b/packages/stacked_themes/lib/src/theme_builder.dart
@@ -99,6 +99,14 @@ class _ThemeBuilderState extends State<ThemeBuilder>
     }
   }
 
+  // Should update theme whenever platform brighteness changes.
+  // This makes sure that theme changes even if the brighteness changes from notification bar.
+  @override
+  void didChangePlatformBrightness() {
+    super.didChangePlatformBrightness();
+    adjustSystemThemeIfNecessary();
+  }
+
   //NOTE: re-apply the appropriate theme when the application gets back into the foreground
   void adjustSystemThemeIfNecessary() {
     switch (themeManager.selectedThemeMode) {

--- a/packages/stacked_themes/lib/src/theme_builder.dart
+++ b/packages/stacked_themes/lib/src/theme_builder.dart
@@ -12,6 +12,7 @@ class ThemeBuilder extends StatefulWidget {
   final ThemeData? lightTheme;
   final ThemeData? darkTheme;
   final Color? Function(ThemeData?)? statusBarColorBuilder;
+  final Color? Function(ThemeData?)? navigationBarColorBuilder;
   final ThemeMode defaultThemeMode;
 
   ThemeBuilder({
@@ -21,6 +22,7 @@ class ThemeBuilder extends StatefulWidget {
     this.lightTheme,
     this.darkTheme,
     this.statusBarColorBuilder,
+    this.navigationBarColorBuilder,
     this.defaultThemeMode = ThemeMode.system,
   }) : super(key: key);
 
@@ -29,6 +31,7 @@ class ThemeBuilder extends StatefulWidget {
         ThemeManager(
           themes: themes,
           statusBarColorBuilder: statusBarColorBuilder,
+          navigationBarColorBuilder: navigationBarColorBuilder,
           darkTheme: darkTheme,
           lightTheme: lightTheme,
           defaultTheme: defaultThemeMode,

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -118,8 +118,15 @@ You can supply either a list of ThemeData objects to the themes property or a li
         _selectedThemeMode = savedUserThemeMode;
       }
 
-      selectedTheme =
-          _selectedThemeMode == ThemeMode.dark ? darkTheme : lightTheme;
+      if (_selectedThemeMode == ThemeMode.system) {
+        final brighteness =
+            SchedulerBinding.instance!.window.platformBrightness;
+        selectedTheme = brighteness == Brightness.dark ? darkTheme : lightTheme;
+      } else {
+        selectedTheme =
+            _selectedThemeMode == ThemeMode.dark ? darkTheme : lightTheme;
+      }
+
       updateOverlayColors(selectedTheme);
     }
 

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -109,7 +109,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
       } else {
         selectedTheme = themes!.first;
       }
-      _updateOverlayColors(selectedTheme);
+      updateOverlayColors(selectedTheme);
     } else {
       _selectedThemeMode = defaultTheme;
 
@@ -120,7 +120,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
 
       selectedTheme =
           _selectedThemeMode == ThemeMode.dark ? darkTheme : lightTheme;
-      _updateOverlayColors(selectedTheme);
+      updateOverlayColors(selectedTheme);
     }
 
     ThemeModel _currTheme = ThemeModel(
@@ -152,7 +152,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
     }
 
     var theme = themes![themeIndex];
-    await _updateOverlayColors(theme);
+    await updateOverlayColors(theme);
 
     _themesController.add(ThemeModel(
       selectedTheme: theme,
@@ -182,7 +182,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
     }
   }
 
-  Future<void> _updateOverlayColors(ThemeData? theme) async {
+  Future<void> updateOverlayColors(ThemeData? theme) async {
     _applyStatusBarColor(theme);
     _applyNavigationBarColor(theme);
   }
@@ -192,7 +192,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
     _selectedThemeMode =
         _selectedThemeMode == ThemeMode.dark ? ThemeMode.light : ThemeMode.dark;
 
-    _updateOverlayColors(
+    updateOverlayColors(
         _selectedThemeMode == ThemeMode.dark ? darkTheme : lightTheme);
     _themesController.add(ThemeModel(
       selectedTheme: lightTheme,
@@ -207,12 +207,12 @@ You can supply either a list of ThemeData objects to the themes property or a li
     _sharedPreferences.userThemeMode = themeMode;
 
     if (themeMode != ThemeMode.system) {
-      _updateOverlayColors(
+      updateOverlayColors(
           _selectedThemeMode == ThemeMode.dark ? darkTheme : lightTheme);
     } else {
       var currentBrightness =
           SchedulerBinding.instance!.window.platformBrightness;
-      _updateOverlayColors(
+      updateOverlayColors(
           currentBrightness == Brightness.dark ? darkTheme : lightTheme);
     }
 

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -120,7 +120,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
 
       if (_selectedThemeMode == ThemeMode.system) {
         final brighteness =
-            SchedulerBinding.instance!.window.platformBrightness;
+            SchedulerBinding.instance?.window.platformBrightness;
         selectedTheme = brighteness == Brightness.dark ? darkTheme : lightTheme;
       } else {
         selectedTheme =

--- a/packages/stacked_themes/lib/src/theme_manager.dart
+++ b/packages/stacked_themes/lib/src/theme_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';
@@ -120,7 +121,7 @@ You can supply either a list of ThemeData objects to the themes property or a li
 
       if (_selectedThemeMode == ThemeMode.system) {
         final brighteness =
-            SchedulerBinding.instance!.window.platformBrightness;
+            SchedulerBinding.instance?.window.platformBrightness;
         selectedTheme = brighteness == Brightness.dark ? darkTheme : lightTheme;
       } else {
         selectedTheme =

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_themes
 description: A set of classes to help you better manage Themes in flutter
-version: 0.3.7
+version: 0.3.8
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_themes
 publish_to: none
 


### PR DESCRIPTION
## Features
- navigation bar color builder

## Fixes
- Fixed overlay colors ( status bar and navigation bar colors ) won't update properly when app is resumed
- Fix: `ThemeManager` fails to pick right theme if default mode is `ThemeMode.system`

## Tests
All tests are working.

```
✓ ThemeManagerTest - Construction - When constructed and last theme index is 1, should broadcast theme at 1 as selected theme
WARNING: You have changed your number of themes. Because of this we will clear your previously selected
        theme and broadcast the first theme in your list of themes.
✓ ThemeManagerTest - Construction - When constructed and last theme index is 2, if the new theme manager has less themes, broadcast first
WARNING: You have changed your number of themes. Because of this we will clear your previously selected
        theme and broadcast the first theme in your list of themes.
✓ ThemeManagerTest - Construction - When constructed and last theme index is 2, if the new theme manager has less themes, reset theme
✓ ThemeManagerTest - Construction - When constructed and no theme has been selected we broadcast the first theme
✓ ThemeManagerTest - themesStream - After construction, should broadcast the first theme from themes
✓ ThemeManagerTest - selectThemeAtIndex - When called and no no themes were supplied should throw exception
✓ ThemeManagerTest - selectThemeAtIndex - When called with index 1, should broadcast the theme at 1 over the themesStream
✓ ThemeManagerTest - selectThemeAtIndex - When called with index, should get status color from the callback
✓ ThemeManagerTest - selectThemeAtIndex - When called with index, should pass color to the status bar service
✓ ThemeManagerTest - selectedThemeIndex - When called should and we do not have multiple themes return null
WARNING: You have changed your number of themes. Because of this we will clear your previously selected
        theme and broadcast the first theme in your list of themes.
✓ ThemeManagerTest - selectedThemeIndex - When sharedPreferences theme index returns 5, selectedThemeIndex should return 5
✓ ThemeManagerTest - selectedThemeIndex - When themeIndex from sharedPreferences returns null, theme index should default to 0
✓ ThemeManagerTest - Dark and Light - When constructed with ThemeMode.system, should broadcast ThemeMode.system in the ThemeModel
✓ ThemeManagerTest - Dark and Light - When constructed with ThemeMode.light, should broadcast ThemeMode.light in the ThemeModel
✓ ThemeManagerTest - Dark and Light - When constructed with ThemeMode.system, should check if user has a savedThemeMode
✓ ThemeManagerTest - Dark and Light - When constructed with ThemeMode.light, and user has saved theme dark, should broadcast dark
✓ ThemeManagerTest - Dark and Light - When manager constructed with Light, When toggleDarkLightTheme is called, should broadcast Dark theme mode
✓ ThemeManagerTest - Dark and Light - When manager constructed with Light, should get the statusColor from the builder
✓ ThemeManagerTest - Dark and Light - When manager constructed with Light, When toggleDarkLightTheme is called, should get the statusColor from the builder
✓ ThemeManagerTest - setThemeMode - When called with ThemeMode.dark, should save the theme mode to shared preferences
✓ ThemeManagerTest - setThemeMode - When called with ThemeMode.dark, should set the status bar color from the ThemeManager
✓ ThemeManagerTest - setThemeMode - When called with ThemeMode.dark, should broadcast the theme data over the theme stream
✓ ThemeManagerTest - Theme Persistence - When a theme changes the index should be persisted into shared preferences
✓ ThemeManagerTest - Theme Persistence - When theme manager contructed, should get the themeIndex from the shared preferences
```
