### PR TITLE
Generic route generation

### DIFF
--- a/packages/stacked/example/lib/app/app.dart
+++ b/packages/stacked/example/lib/app/app.dart
@@ -11,7 +11,6 @@ import 'package:new_architecture/ui/nonreactive/nonreactive_view.dart';
 import 'package:new_architecture/ui/stream_view/stream_counter_view.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked/stacked_annotations.dart';
-import 'package:stacked_crashlytics/stacked_crashlytics.dart';
 import 'package:stacked_services/stacked_services.dart';
 import 'package:stacked_themes/stacked_themes.dart';
 
@@ -20,7 +19,7 @@ import 'package:stacked_themes/stacked_themes.dart';
     MaterialRoute(page: HomeView, initial: true),
     MaterialRoute(page: BottomNavExample),
     MaterialRoute(page: StreamCounterView),
-    CupertinoRoute(page: DetailsView),
+    CupertinoRoute<Map<String, List<String>>>(page: DetailsView),
     // TODO: Change the name of the FormView to avoid type clashing
     MaterialRoute(page: ExampleFormView),
     CustomRoute(

--- a/packages/stacked/example/lib/app/app.router.dart
+++ b/packages/stacked/example/lib/app/app.router.dart
@@ -9,6 +9,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:stacked/stacked.dart';
+import 'package:stacked/stacked_annotations.dart';
 
 import '../ui/bottom_nav/bottom_nav_example.dart';
 import '../ui/details/details_view.dart';
@@ -68,7 +69,7 @@ class StackedRouter extends RouterBase {
     },
     DetailsView: (data) {
       var args = data.getArgs<DetailsViewArguments>(nullOk: false);
-      return CupertinoPageRoute<dynamic>(
+      return CupertinoPageRoute<Map<String, List<String>>>(
         builder: (context) => DetailsView(
           key: args.key,
           name: args.name,

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6
+
+- Fixed Route generation with generic return types
+
 ## 0.5.5
 
 - Reverts update from 0.5.4 lol. (sorry, some confusion with a different bug)

--- a/packages/stacked_generator/lib/src/generators/router/router_class_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/router/router_class_generator.dart
@@ -273,7 +273,7 @@ class RouterClassGenerator extends BaseGenerator {
           r.returnType!.contains('AdaptiveRoute')) {
         // get the correct return type
         final type = r.returnType!.substring(
-            r.returnType!.indexOf('<') + 1, r.returnType!.indexOf('>'));
+            r.returnType!.indexOf('<') + 1, r.returnType!.lastIndexOf('>'));
         r.returnType = type;
       }
     }

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.5.5
+version: 0.5.6
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
- Fixed Route Generation with generic return types

## Bug Preview 
```dart
// Route
  CupertinoRoute<Map<String, List<String>>>(page: DetailsView),

// Generated Code
DetailsView: (data) {
var args = data.getArgs<DetailsViewArguments>(nullOk: false);
return CupertinoPageRoute<Map<String, List<String>(builder: (context) => DetailsView(key:args.key,name:args.name,), settings: data,);
},
```

## Fix
```dart
// Route
  CupertinoRoute<Map<String, List<String>>>(page: DetailsView),

// Generated Code
 DetailsView: (data) {
      var args = data.getArgs<DetailsViewArguments>(nullOk: false);
      return CupertinoPageRoute<Map<String, List<String>>>(
        builder: (context) => DetailsView(
          key: args.key,
          name: args.name,
        ),
        settings: data,
      );
    },
```