### PR TITLE
:bug: Omitted logs in release mode

### DIFF
--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -122,6 +122,24 @@ class MultipleLoggerOutput extends LogOutput {
   }
 }
 
+/// Prints all logs with `level >= Logger.level` while in development mode (eg
+/// when `assert`s are evaluated, Flutter calls this debug mode).
+///
+/// In release mode ALL logs are omitted.
+class StackedFilter extends LogFilter {
+  @override
+  bool shouldLog(LogEvent event) {
+    var shouldLog = false;
+    assert(() {
+      if (event.level.index >= level!.index) {
+        shouldLog = true;
+      }
+      return true;
+    }());
+    return shouldLog;
+  }
+}
+
 Logger $LogHelperNameKey(
   String className, {
   bool printCallingFunctionName = true,
@@ -130,6 +148,7 @@ Logger $LogHelperNameKey(
   String? showOnlyClass,
 }) {
   return Logger(
+    filter: StackedFilter(),
     printer: SimpleLogPrinter(
       className,
       printCallingFunctionName: printCallingFunctionName,


### PR DESCRIPTION
This PR makes sure logs are omitted in release mode. Based on the logger's recommendation

![Capture](https://user-images.githubusercontent.com/36260221/145561418-ff2a81e7-5ca4-429d-9486-4b4e7f84ae05.PNG)
 
 I did a reimplementation of the filter class 