### PR TITLE
bumped analyzer 2.0.0=>3.0.0. This fixes compatibility with freezed v…

### DIFF
--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   build: ^2.0.0
   source_gen: ^1.0.0
-  analyzer: ^2.0.0
+  analyzer: ^3.0.0
   path: ^1.6.4
   # logger: ^1.0.0
   recase: ^4.0.0-nullsafety.0


### PR DESCRIPTION
bumped analyzer 2.0.0=>3.0.0. This fixes compatibility with freezed v. 1.1.1.