### PR TITLE
Fix the generated code of FactoryWithParam with asType

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+- Fixed code generation bug when using `FactoryWithParam` with the `asType` argument set
+
 ## 0.6.2
 
 - Enables multi logger output only in release mode

--- a/packages/stacked_generator/lib/src/generators/getit/stacked_locator_content_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/stacked_locator_content_generator.dart
@@ -89,7 +89,8 @@ class StackedLocatorContentGenerator extends BaseGenerator {
           _params["params"]?.isEmpty ?? true,
           "At least one paramter is requerd for FactoryWithParam registration ",
         );
-        return '$locatorName.registerFactoryParam<${dependencyDefinition.className},${_params["paramTypes"]}>$abstractionType((param1, param2) => ${dependencyDefinition.className}(${_params["params"]})  $_formattedEnvs);';
+        final typeOfService = hasAbstratedType ? dependencyDefinition.abstractedTypeClassName : dependencyDefinition.className;
+        return '$locatorName.registerFactoryParam<${typeOfService},${_params["paramTypes"]}>((param1, param2) => ${dependencyDefinition.className}(${_params["params"]})  $_formattedEnvs);';
       case DependencyType.Singleton:
       default:
         return '$locatorName.registerSingleton$abstractionType($singletonInstanceToReturn  $_formattedEnvs);';

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.6.2
+version: 0.6.3
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
I faced an error of  generated code when I used `FactoryWithParam` with `asType`.
The original generated code will produce like this

```
exampleLocator.registerFactoryParam<FactoryService, String?, double?><IFactoryService>((param1, param2) => FactoryService(key: param1, value: param2));
``` 

I tried to fix and then the revised generated code will produce like this

```
exampleLocator.registerFactoryParam<IFactoryService, String?, double?>((param1, param2) => FactoryService(key: param1, value: param2));
```