### PR TITLE
fix: invalid named arg on documentation

### DIFF
--- a/packages/stacked/README.md
+++ b/packages/stacked/README.md
@@ -565,7 +565,7 @@ class InformationService with ReactiveServiceMixin { //1
   }
 
   //2
-  ReactiveValue<int> _postCount = ReactiveValue<int>(initial: 0);
+  ReactiveValue<int> _postCount = ReactiveValue<int>(0);
   int get postCount => _postCount.value;
 
   void updatePostCount() {


### PR DESCRIPTION
Fixed a small documentation problem, where the documentation used a named argument when there was none

Currently on the documentation:
<img width="563" alt="Screenshot 2022-04-15 at 13 11 02" src="https://user-images.githubusercontent.com/20175372/163564316-cd8b5178-524c-471c-987a-29c61e996683.png">

Real implementation:
[reactive_value.dart](
https://github.com/FilledStacks/stacked/blob/master/packages/stacked/lib/src/reactive/reactive_value/reactive_value.dart)
