### PR TITLE
Use dependency overrides instead of comment out/in the local  dependency

### DIFF
--- a/packages/stacked/example/lib/app/app.locator.dart
+++ b/packages/stacked/example/lib/app/app.locator.dart
@@ -7,7 +7,7 @@
 // ignore_for_file: public_member_api_docs
 
 import 'package:stacked/stacked.dart';
-import 'package:stacked/stacked_annotations.dart';
+import 'package:stacked_core/stacked_core.dart';
 import 'package:stacked_services/stacked_services.dart';
 import 'package:stacked_themes/stacked_themes.dart';
 
@@ -19,8 +19,8 @@ import '../ui/bottom_nav/history/history_viewmodel.dart';
 
 final exampleLocator = StackedLocator.instance;
 
-void setupExampleLocator(
-    {String? environment, EnvironmentFilter? environmentFilter}) {
+Future<void> setupExampleLocator(
+    {String? environment, EnvironmentFilter? environmentFilter}) async {
 // Register environments
   exampleLocator.registerEnvironment(
       environment: environment, environmentFilter: environmentFilter);

--- a/packages/stacked/example/lib/app/app.logger.dart
+++ b/packages/stacked/example/lib/app/app.logger.dart
@@ -9,8 +9,9 @@
 /// Maybe this should be generated for the user as well?
 ///
 /// import 'package:customer_app/services/stackdriver/stackdriver_service.dart';
-import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+
+const bool _isReleaseMode = bool.fromEnvironment("dart.vm.product");
 
 class SimpleLogPrinter extends LogPrinter {
   final String className;
@@ -48,7 +49,7 @@ class SimpleLogPrinter extends LogPrinter {
 
     for (var line in output.split('\n')) {
       result.addAll(pattern.allMatches(line).map((match) {
-        if (kReleaseMode) {
+        if (_isReleaseMode) {
           return match.group(0)!;
         } else {
           return color!(match.group(0)!);
@@ -138,7 +139,7 @@ Logger getLogger(
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
     output: MultipleLoggerOutput([
-      if (!kReleaseMode) ConsoleOutput(),
+      if (!_isReleaseMode) ConsoleOutput(),
     ]),
   );
 }

--- a/packages/stacked/example/pubspec.yaml
+++ b/packages/stacked/example/pubspec.yaml
@@ -32,12 +32,12 @@ dependencies:
   stacked_themes:
   stacked_crashlytics:
   
-  flutter_hooks:
+  flutter_hooks: ^0.18.4
   # navigation
-  get:
+  get: ^4.6.3
 
   # logging
-  logger:
+  logger: ^1.1.0
 
 dependency_overrides: 
   stacked:

--- a/packages/stacked/example/pubspec.yaml
+++ b/packages/stacked/example/pubspec.yaml
@@ -36,9 +36,6 @@ dependencies:
   # navigation
   get: ^4.6.3
 
-  # logging
-  logger: ^1.1.0
-
 dependency_overrides: 
   stacked:
       path: ../

--- a/packages/stacked/example/pubspec.yaml
+++ b/packages/stacked/example/pubspec.yaml
@@ -27,20 +27,32 @@ dependencies:
 
   # state management
   stacked:
-    path: ../
   stacked_services:
-    path: ../../stacked_services/
   stacked_hooks:
-  flutter_hooks:
   stacked_themes:
-    path: ../../stacked_themes/
   stacked_crashlytics:
-    path: ../../stacked_crashlytics/
+  
+  flutter_hooks:
   # navigation
   get:
 
   # logging
   logger:
+
+dependency_overrides: 
+  stacked:
+      path: ../
+  stacked_services:
+    path: ../../stacked_services/
+  stacked_hooks:
+    path: ../../stacked_hooks/
+  stacked_themes:
+    path: ../../stacked_themes/
+  stacked_crashlytics:
+    path: ../../stacked_crashlytics/
+  stacked_generator:
+    path: ../../stacked_generator
+
 
 dev_dependencies:
   flutter_test:
@@ -50,6 +62,7 @@ dev_dependencies:
   build_runner:
   stacked_generator:
     # path: ../../stacked_generator
+  
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -16,9 +16,13 @@ dependencies:
   provider: ^6.0.0 #5.0.0
   collection: ^1.15.0
   # Remove the path and use pub one after publish the stacked_core
-  stacked_core: ^1.1.0
+  stacked_core:
   #universal_io
   universal_io: ^2.0.4
+
+dependency_overrides:
+  stacked_core:
+    path: ../stacked_core/
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_generator/lib/src/generators/forms/form_generator_util.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_generator_util.dart
@@ -10,7 +10,8 @@ class FormGeneratorUtil extends BaseGenerator {
   List<FieldConfig> get fields => formViewConfig.fields;
   String get viewName => formViewConfig.viewName;
 
-  String generateForm() {
+  @override
+  String generate() {
     writeLine("// ignore_for_file: public_member_api_docs");
 
     generateImports();

--- a/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/stacked_form_content_generator.dart
@@ -9,6 +9,6 @@ class StackedFormContentGenerator {
 
   String generate() {
     _util = FormGeneratorUtil(formViewConfig: _formViewConfig);
-    return _util.generateForm();
+    return _util.generate();
   }
 }

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   freezed: ^2.0.3
   freezed_annotation: ^2.0.3
   logger: ^1.1.0
-  stacked_core: ^1.1.0
+  stacked_core:
   
 dev_dependencies:
   build_runner: ^2.0.6

--- a/packages/stacked_gql/pubspec.yaml
+++ b/packages/stacked_gql/pubspec.yaml
@@ -1,7 +1,6 @@
 name: stacked_gql
 description: A package that improves the usability of gql in flutter applications.
 version: 0.0.1
-homepage:
 
 environment:
   sdk: ">=2.13.0 <3.0.0"

--- a/packages/stacked_hooks/example/pubspec.yaml
+++ b/packages/stacked_hooks/example/pubspec.yaml
@@ -25,8 +25,13 @@ dependencies:
   cupertino_icons: ^0.1.2
   stacked:
   stacked_hooks:
-    path: ../
   flutter_hooks:
+
+dependency_overrides: 
+  stacked:
+    path: ../../stacked/
+  stacked_hooks:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_localisation/stacked_localisation/example/pubspec.yaml
+++ b/packages/stacked_localisation/stacked_localisation/example/pubspec.yaml
@@ -27,15 +27,22 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
-  stacked: ^1.7.6
-  stacked_services: ^0.5.2
+  stacked: 
+  stacked_services: 
   stacked_localisation:
-    path: ../
 
-  get_it: ^4.0.4
+  get_it: ^7.1.4
 
   # navigation
   auto_route: ^0.6.7
+
+dependency_overrides: 
+  stacked: 
+    path: ../../../stacked/
+  stacked_services:
+    path: ../../../stacked_services/
+  stacked_localisation:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_localisation/stacked_localisation/pubspec.yaml
+++ b/packages/stacked_localisation/stacked_localisation/pubspec.yaml
@@ -11,8 +11,12 @@ dependencies:
     sdk: flutter
 
   devicelocale: ^0.3.1
-  get_it: ^4.0.4
-  stacked_core: ^1.1.0
+  get_it: ^7.1.4
+  stacked_core: 
+
+dependency_overrides:
+  stacked_core:
+    path: ../../stacked_core/
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_localisation/stacked_localisation/test/test_helpers.dart
+++ b/packages/stacked_localisation/stacked_localisation/test/test_helpers.dart
@@ -14,7 +14,7 @@ LocalisationService getAndRegisterLocalistionService(
     {String localisationString = 'hello, world'}) {
   _removeRegistrationIfExists<LocalisationService>();
   var mock = LocalisationServiceMock();
-  when(mock[any]).thenReturn(localisationString);
+  // when(mock[any]).thenReturn(localisationString);
   locator.registerSingleton<LocalisationService>(mock);
   return mock;
 }
@@ -37,7 +37,7 @@ StringReader getAndRegisterStringReaderMock() {
 
 // Call this before any service registration helper. This is to ensure that if there
 // is a service registered we remove it first. We register all services to remove boiler plate from tests
-void _removeRegistrationIfExists<T>() {
+void _removeRegistrationIfExists<T extends Object>() {
   if (locator.isRegistered<T>()) {
     locator.unregister<T>();
   }

--- a/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
+++ b/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
@@ -7,13 +7,13 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  build: ^1.3.0
-  source_gen: ^0.9.6
-  analyzer:
+  build: ^2.3.0
+  source_gen: ^1.2.2
+  analyzer: ^4.1.0
   mustache: ^1.1.1
-  glob: ^1.2.0
+  glob: ^2.0.0
   path: ^1.6.4
-  yaml: ^2.2.1
+  yaml: ^3.0.0
 
 dev_dependencies:
   test:

--- a/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
+++ b/packages/stacked_localisation/stacked_localisation_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   build: ^1.3.0
   source_gen: ^0.9.6
-  analyzer: ^0.39.17
+  analyzer:
   mustache: ^1.1.1
   glob: ^1.2.0
   path: ^1.6.4

--- a/packages/stacked_services/example/pubspec.yaml
+++ b/packages/stacked_services/example/pubspec.yaml
@@ -27,6 +27,11 @@ dependencies:
   injectable:
   stacked:
   stacked_services:
+  
+dependency_overrides: 
+  stacked:
+    path: ../../stacked
+  stacked_services:
     path: ../
 
 dev_dependencies:

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -10,12 +10,17 @@ dependencies:
   flutter:
     sdk: flutter
 
-  stacked_core: ^1.1.0
+  stacked_core:
 
   # navigation
   get: ^4.5.1
 
   crypto: ^3.0.1
+
+dependency_overrides: 
+  stacked_core:
+    path: ../stacked_core/
+
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_themes/example/pubspec.yaml
+++ b/packages/stacked_themes/example/pubspec.yaml
@@ -29,8 +29,13 @@ dependencies:
   cupertino_icons: ^0.1.3
   stacked:
   stacked_themes:
-    path: ../
   get_it:
+
+dependency_overrides: 
+  stacked:
+    path: ../../stacked/
+  stacked_themes:
+    path: ../ 
 
 dev_dependencies:
   flutter_test:

--- a/packages/stacked_themes/example/pubspec.yaml
+++ b/packages/stacked_themes/example/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   cupertino_icons: ^0.1.3
   stacked:
   stacked_themes:
-  get_it:
+  get_it: ^7.2.0
 
 dependency_overrides: 
   stacked:

--- a/packages/stacked_themes/pubspec.yaml
+++ b/packages/stacked_themes/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  stacked_core: ^1.1.0
+  stacked_core:
 
   provider: ^6.0.0
   rxdart: ^0.27.1
@@ -20,6 +20,10 @@ dependencies:
 
   #universal_io
   universal_io: ^2.0.4
+
+dependency_overrides: 
+  stacked_core: 
+    path: ../stacked_core/
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Adds all local package to dependency overides to use path on dev

- Fixes flutter V3 introduced bugs