### PR TITLE
Fix/routes is not required in stackedapp

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.7.4
+- Prevent throwing an error when routes is not provided in StackedApp
 ## 0.7.3
 - Fixes Import for Adaptive Route
 ## 0.7.2

--- a/packages/stacked_generator/lib/src/generators/router/stacked_router_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/router/stacked_router_generator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:stacked_core/stacked_core.dart';
 import 'package:stacked_generator/import_resolver.dart';
@@ -9,19 +11,20 @@ import 'generator/router_class_generator.dart';
 
 class StackedRouterGenerator extends GeneratorForAnnotation<StackedApp> {
   @override
-  dynamic generateForAnnotatedElement(
+  FutureOr<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
   ) async {
-    var libs = await buildStep.resolver.libraries.toList();
-    var importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
+    final libs = await buildStep.resolver.libraries.toList();
+    final importResolver = ImportResolver(libs, element.source?.uri.path ?? '');
 
-    var routerResolver = RouterConfigResolver(importResolver);
-    final routerConfig = await routerResolver.resolve(
-      annotation,
-    );
+    final routerConfig =
+        await RouterConfigResolver(importResolver).resolve(annotation);
 
-    return RouterClassGenerator(routerConfig).generate();
+    if (routerConfig != null)
+      return RouterClassGenerator(routerConfig).generate();
+    else
+      return '';
   }
 }

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.7.3
+version: 0.7.4
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
Fix #649 
- When routes are not provided don't throw an exception 
- When routes are not provided don't generate anything