### PR TITLE
Fix/future and stream viewmodels seterror

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.3.2
+- Fix [#486](https://github.com/FilledStacks/stacked/issues/486) 
 ## 2.3.11
 - Fix [#546](https://github.com/FilledStacks/stacked/issues/546) 
 ## 2.3.10

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -226,7 +226,13 @@ class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel {
 
   @override
   dynamic error([Object? object]) => _error;
+  @override
+  void setError(error) {
+    _error = error;
+    super.setError(error);
+  }
 
+  bool get hasError => error(this) != null;
   bool get dataReady => _data != null && !hasError;
 }
 

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -2,7 +2,7 @@ name: stacked
 description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
-version: 2.3.11
+version: 2.3.2
 homepage: https://github.com/FilledStacks/stacked
 
 environment:

--- a/packages/stacked/test/futureviewmodel_test.dart
+++ b/packages/stacked/test/futureviewmodel_test.dart
@@ -24,6 +24,10 @@ class TestFutureViewModel extends FutureViewModel<int?> {
     return numberToReturn;
   }
 
+  void setErrorManually() {
+    setError('my error');
+  }
+
   @override
   void onData(int? data) {
     dataCalled = true;
@@ -67,6 +71,12 @@ class TestMultipleFutureViewModel extends MultipleFutureViewModel {
 
 void main() {
   group('FutureViewModel', () {
+    test('When error is manually set, hasError should be true', () async {
+      var futureViewModel = TestFutureViewModel();
+      futureViewModel.setErrorManually();
+
+      expect(futureViewModel.hasError, isTrue);
+    });
     test('When future is complete data should be set and ready', () async {
       var futureViewModel = TestFutureViewModel();
       await futureViewModel.initialise();

--- a/packages/stacked/test/streamviewmodel_test.dart
+++ b/packages/stacked/test/streamviewmodel_test.dart
@@ -20,6 +20,9 @@ class TestStreamViewModel extends StreamViewModel<int> {
   final int delay;
   TestStreamViewModel({this.fail = false, this.delay = 0});
   int? loadedData;
+  void setErrorManually() {
+    setError('my error');
+  }
 
   @override
   get stream => numberStream(1, fail: fail, delay: delay);
@@ -95,7 +98,13 @@ void main() async {
       await Future.delayed(Duration(milliseconds: 1));
       expect(streamViewModel.loadedData, 1);
     });
-
+    test('When error is manually set, hasError should be true', () async {
+      var streamViewModel = TestStreamViewModel();
+      streamViewModel.initialise();
+      await Future.delayed(Duration(milliseconds: 1));
+      streamViewModel.setErrorManually();
+      expect(streamViewModel.hasError, isTrue);
+    });
     test('When a stream fails it should indicate there\'s an error and no data',
         () async {
       var streamViewModel = TestStreamViewModel(fail: true);


### PR DESCRIPTION
  Closes #486 
  - Fix setError manually for futureviewmodel
  - Fix setError manually for streamviewmodel that last until the next emit of the stream