### PR TITLE
Add Sign In with phone number support for Native Platform

### DIFF
--- a/packages/stacked_firebase_auth/CHANGELOG.md
+++ b/packages/stacked_firebase_auth/CHANGELOG.md
@@ -1,6 +1,4 @@
 ## 0.2.13
-- Remove signInWithPhoneNumber (implements Web Platform)
-- Remove verifyOtp (Implements Web Platform)
 - Add requestVerificationCode (Implements Native Platform)
 - Add authenticateWithOtp (Implements Native Platform)
 

--- a/packages/stacked_firebase_auth/CHANGELOG.md
+++ b/packages/stacked_firebase_auth/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.13
+- Remove signInWithPhoneNumber (implements Web Platform)
+- Remove verifyOtp (Implements Web Platform)
+- Add requestVerificationCode (Implements Native Platform)
+- Add authenticateWithOtp (Implements Native Platform)
+
 ## 0.2.12
 - Adds sign in with phone number
 - Adds verify otp 

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -369,6 +369,38 @@ class FirebaseAuthenticationService {
     );
   }
 
+  /// Authenticate the user using SMS code [otp]
+  Future<FirebaseAuthenticationResult> authenticateWithOtp(String otp) async {
+    if (_mobileVerificationId == null) {
+      throw 'The _mobileVerificationId should not be null here. Verification was probably skipped.';
+    }
+
+    try {
+      final phoneAuthCredential = PhoneAuthProvider.credential(
+        verificationId: _mobileVerificationId!,
+        smsCode: otp,
+      );
+
+      final userCredential = await firebaseAuth.signInWithCredential(
+        phoneAuthCredential,
+      );
+
+      return FirebaseAuthenticationResult(user: userCredential.user);
+    } on FirebaseAuthException catch (e) {
+      log?.e('A Firebase exception has occured. $e');
+      return FirebaseAuthenticationResult.error(
+        exceptionCode: e.code.toLowerCase(),
+        errorMessage: getErrorMessageFromFirebaseException(e),
+      );
+    } on Exception catch (e) {
+      log?.e('A general exception has occured. $e');
+      return FirebaseAuthenticationResult.error(
+        errorMessage:
+            'We could not authenticate with OTP at this time. Please try again.',
+      );
+    }
+  }
+
   /// Sign out of the social accounts that have been used
   Future logout() async {
     log?.i('');

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -320,6 +320,8 @@ class FirebaseAuthenticationService {
   }
 
   /// Phone Number Login
+  ///
+  /// Web Platform support
   Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber) async {
     try {
       return firebaseAuth.signInWithPhoneNumber(phoneNumber);
@@ -332,6 +334,9 @@ class FirebaseAuthenticationService {
     }
   }
 
+  /// Verify SMS code using [confirmationResult] and [otp]
+  ///
+  /// Web Platform support
   Future<FirebaseAuthenticationResult> verifyOtp(
       ConfirmationResult confirmationResult, String otp) async {
     try {
@@ -347,6 +352,8 @@ class FirebaseAuthenticationService {
   }
 
   /// Request a SMS verification code for [phoneNumber] sign-in.
+  ///
+  /// Native Platform support
   Future<void> requestVerificationCode({
     required String phoneNumber,
     void Function(FirebaseAuthenticationResult authenticationResult)?
@@ -397,6 +404,8 @@ class FirebaseAuthenticationService {
   }
 
   /// Authenticate the user using SMS code [otp]
+  ///
+  /// Native Platform support
   Future<FirebaseAuthenticationResult> authenticateWithOtp(String otp) async {
     if (_mobileVerificationId == null) {
       throw 'The _mobileVerificationId should not be null here. Verification was probably skipped.';

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -319,6 +319,33 @@ class FirebaseAuthenticationService {
     );
   }
 
+  /// Phone Number Login
+  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber) async {
+    try {
+      return firebaseAuth.signInWithPhoneNumber(phoneNumber);
+    } catch (e) {
+      throw FirebaseAuthenticationResult.error(
+        errorMessage:
+            'We could not send a verification code to your phone number. Please try again.',
+        exceptionCode: e.toString(),
+      );
+    }
+  }
+
+  Future<FirebaseAuthenticationResult> verifyOtp(
+      ConfirmationResult confirmationResult, String otp) async {
+    try {
+      UserCredential userCredential = await confirmationResult.confirm(otp);
+      return FirebaseAuthenticationResult(user: userCredential.user);
+    } catch (e) {
+      throw FirebaseAuthenticationResult.error(
+        errorMessage:
+            'We could not verify the otp at this time. Please try again.',
+        exceptionCode: e.toString(),
+      );
+    }
+  }
+
   /// Request a SMS verification code for [phoneNumber] sign-in.
   Future<void> requestVerificationCode({
     required String phoneNumber,

--- a/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
+++ b/packages/stacked_firebase_auth/lib/src/firebase_authentication_service.dart
@@ -317,33 +317,6 @@ class FirebaseAuthenticationService {
     );
   }
 
-  /// Phone Number Login
-  Future<ConfirmationResult> signInWithPhoneNumber(String phoneNumber) async {
-    try {
-      return firebaseAuth.signInWithPhoneNumber(phoneNumber);
-    } catch (e) {
-      throw FirebaseAuthenticationResult.error(
-        errorMessage:
-            'We could not send a verification code to your phone number. Please try again.',
-        exceptionCode: e.toString(),
-      );
-    }
-  }
-
-  Future<FirebaseAuthenticationResult> verifyOtp(
-      ConfirmationResult confirmationResult, String otp) async {
-    try {
-      UserCredential userCredential = await confirmationResult.confirm(otp);
-      return FirebaseAuthenticationResult(user: userCredential.user);
-    } catch (e) {
-      throw FirebaseAuthenticationResult.error(
-        errorMessage:
-            'We could not verify the otp at this time. Please try again.',
-        exceptionCode: e.toString(),
-      );
-    }
-  }
-
   /// Sign out of the social accounts that have been used
   Future logout() async {
     log?.i('');

--- a/packages/stacked_firebase_auth/lib/stacked_firebase_auth.dart
+++ b/packages/stacked_firebase_auth/lib/stacked_firebase_auth.dart
@@ -1,3 +1,5 @@
 library stacked_firebase_auth;
 
 export 'src/firebase_authentication_service.dart';
+export 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart'
+    show FirebaseAuthException;

--- a/packages/stacked_firebase_auth/pubspec.yaml
+++ b/packages/stacked_firebase_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
-version: 0.2.12
+version: 0.2.13
 homepage: https://github.com/FilledStacks/stacked
 
 environment:


### PR DESCRIPTION
Adds Sign In with phone number support for Native Platform.

Also, `FirebaseAuthException` is exported to avoid firebase_auth dependency when using stacked_firebase_auth.

## Reference
The Firebase Authentication SDK for Flutter provides two individual ways to sign a user in with their phone number. Native (e.g. Android & iOS) platforms provide different functionality to validating a phone number than the web, therefore two methods exist for each platform exclusively:

Native Platform: verifyPhoneNumber.
Web Platform: signInWithPhoneNumber.

Reference: [link](https://firebase.google.com/docs/auth/flutter/phone-auth)