### PR TITLE
Hide the `message` widget in `showCustomSnackBar`

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.9.1
+- Hide the `message` widget in `showCustomSnackBar` when the message color is null and message is empty 
 ## 0.9.0
 - ⚠️ Break Change ⚠️: Removed the following deprecated code from snackbar_service
   - `navigatorKey` getter

--- a/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
@@ -160,18 +160,21 @@ class SnackbarService {
               textAlign: snackbarConfig.titleTextAlign,
             )
           : snackbarConfig.titleText ?? null,
-      messageText: Text(
-        message,
-        key: Key('snackbar_text_message'),
-        style: snackbarConfig.messageTextStyle ??
-            messageTextStyle ??
-            TextStyle(
-              color: snackbarConfig.messageColor ?? snackbarConfig.textColor,
-              fontWeight: FontWeight.w300,
-              fontSize: 14,
-            ),
-        textAlign: snackbarConfig.messageTextAlign,
-      ),
+      messageText: _snackbarConfig?.messageColor != null || message.isNotEmpty
+          ? Text(
+              message,
+              key: Key('snackbar_text_message'),
+              style: snackbarConfig.messageTextStyle ??
+                  messageTextStyle ??
+                  TextStyle(
+                    color:
+                        snackbarConfig.messageColor ?? snackbarConfig.textColor,
+                    fontWeight: FontWeight.w300,
+                    fontSize: 14,
+                  ),
+              textAlign: snackbarConfig.messageTextAlign,
+            )
+          : SizedBox.shrink(),
       icon: snackbarConfig.icon,
       shouldIconPulse: snackbarConfig.shouldIconPulse,
       maxWidth: snackbarConfig.maxWidth,


### PR DESCRIPTION
- Hide the `message` widget in `showCustomSnackBar` when the message color is null and message is empty