### PR TITLE
Call until() from Get instead Flutter's popUntil()

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.9.4
+- Adds `id` to the `popUntil` function in `NavigationService` to allow for nested navigation
 ## 0.9.3
 - Only make arguments map when transition is available
 - Fixes [#656](https://github.com/FilledStacks/stacked/issues/656)

--- a/packages/stacked_services/lib/src/navigation/navigation_service.dart
+++ b/packages/stacked_services/lib/src/navigation/navigation_service.dart
@@ -174,8 +174,10 @@ class NavigationService {
   }
 
   /// Pops the back stack until the predicate is satisfied
-  void popUntil(RoutePredicate predicate) {
-    G.Get.key.currentState?.popUntil(predicate);
+  ///
+  /// [id] is for when you are using nested navigation, as explained in documentation.
+  void popUntil(RoutePredicate predicate, {int? id}) {
+    G.Get.until(predicate, id: id);
   }
 
   /// Pops the back stack the number of times you indicate with [popTimes]

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.9.3
+version: 0.9.4
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:


### PR DESCRIPTION
Previously, the `popUntil()` method in `NavigationService` called Flutter's method, instead of calling the one that comes with GetX. That meant that it did not work with nested navigators.

This pull request changes the method to call `until()` from GetX, but keeps the name in `NavigationService` as `popUntil()` to maintain backwards compatibility.