### PR TITLE
refactor/stacked refactor

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.4.0
+
+- Refactor `BaseViewModel` by extracting the different functionalities to mixins.
+- Remove the inconsistency between the `BaseViewModel` and `FutureViewModel`, `StreamViewModel` when setting the error, data values.
+- Now we have three mixins that can be mix with any viewmodel and they are:
+  - `FutureRunnerHelper` that has `runBusyFuture` and `runErrorFuture` functions
+  - `MessageStateHelper` that adds message proberty to the viewmodel
+  - `DataStateHelper` that adds data proberty to the viewmodel
 ## 2.3.15
 
 - Rename `SelectorViewModelBuilderWidget` and `SelectorViewModelWidget` similar to `ViewModelWidget`

--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,11 +1,14 @@
-## 2.4.0
+## 3.0.0-beta.0
 
 - Refactor `BaseViewModel` by extracting the different functionalities to mixins.
 - Remove the inconsistency between the `BaseViewModel` and `FutureViewModel`, `StreamViewModel` when setting the error, data values.
 - Now we have three mixins that can be mix with any viewmodel and they are:
-  - `FutureRunnerHelper` that has `runBusyFuture` and `runErrorFuture` functions
-  - `MessageStateHelper` that adds message proberty to the viewmodel
-  - `DataStateHelper` that adds data proberty to the viewmodel
+  - `FutureRunnerHelper` that has `runBusyFuture` and `runErrorFuture` functions.
+  - `MessageStateHelper` that adds message proberty to the viewmodel.
+  - `DataStateHelper` that adds data proberty to the viewmodel.
+  - `FormStateHelper` that give the flexibility to mixin the form functionality with the  any other view model.
+  - `IndexTrackingStateHelper` that give the flexibility to mixin the index tracking in a bottom navigation bar any other view model.
+
 ## 2.3.15
 
 - Rename `SelectorViewModelBuilderWidget` and `SelectorViewModelWidget` similar to `ViewModelWidget`

--- a/packages/stacked/example/lib/ui/bottom_nav/bottom_nav_example_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/bottom_nav/bottom_nav_example_viewmodel.dart
@@ -6,7 +6,8 @@ import 'package:example/ui/bottom_nav/history/history_view.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
-class BottomNavExampleViewModel extends IndexTrackingViewModel {
+class BottomNavExampleViewModel extends BaseViewModel
+    with IndexTrackingStateHelper {
   final log = getLogger('BottomNavExampleViewModel');
   final _navigationService = exampleLocator<NavigationService>();
 

--- a/packages/stacked/example/lib/ui/drop_down_menu_from/select_location_view.form.dart
+++ b/packages/stacked/example/lib/ui/drop_down_menu_from/select_location_view.form.dart
@@ -31,7 +31,7 @@ final Map<String, String> ProvinceValueToTitleMap = {
 mixin $SelectLocationView on StatelessWidget {
   /// Registers a listener on every generated controller that calls [model.setData()]
   /// with the latest textController values
-  void listenToFormUpdated(FormViewModel model) {}
+  void listenToFormUpdated(FormStateHelper model) {}
 
   /// Calls dispose on all the generated controllers and focus nodes
   void disposeForm() {
@@ -39,7 +39,7 @@ mixin $SelectLocationView on StatelessWidget {
   }
 }
 
-extension ValueProperties on FormViewModel {
+extension ValueProperties on FormStateHelper {
   bool get isFormValid =>
       this.fieldsValidationMessages.values.every((element) => element == null);
   String? get countryValue => this.formValueMap[CountryValueKey] as String?;
@@ -59,7 +59,7 @@ extension ValueProperties on FormViewModel {
       this.fieldsValidationMessages[ProvinceValueKey];
 }
 
-extension Methods on FormViewModel {
+extension Methods on FormStateHelper {
   void setCountry(String country) {
     this.setData(this.formValueMap..addAll({CountryValueKey: country}));
   }

--- a/packages/stacked/example/lib/ui/drop_down_menu_from/select_location_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/drop_down_menu_from/select_location_viewmodel.dart
@@ -4,7 +4,7 @@ import '../../app/app.logger.dart';
 
 const String SelectLocationViewName = 'SelectLocationView';
 
-class SelectLocationViewModel extends FormViewModel {
+class SelectLocationViewModel extends BaseViewModel with FormStateHelper {
   var log = getLogger('SelectLocationViewModel');
 
   @override

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -79,20 +79,20 @@ mixin $ExampleFormView on StatelessWidget {
 
   /// Registers a listener on every generated controller that calls [model.setData()]
   /// with the latest textController values
-  void listenToFormUpdated(FormViewModel model) {
+  void listenToFormUpdated(FormStateHelper model) {
     emailController.addListener(() => _updateFormData(model));
     passwordController.addListener(() => _updateFormData(model));
     shortBioController.addListener(() => _updateFormData(model));
   }
 
   final bool _autoTextFieldValidation = false;
-  bool validateFormFields(FormViewModel model) {
+  bool validateFormFields(FormStateHelper model) {
     _updateFormData(model, forceValidate: true);
     return model.isFormValid;
   }
 
-  /// Updates the formData on the FormViewModel
-  void _updateFormData(FormViewModel model, {bool forceValidate = false}) {
+  /// Updates the formData on the FormStateHelper
+  void _updateFormData(FormStateHelper model, {bool forceValidate = false}) {
     model.setData(
       model.formValueMap
         ..addAll({
@@ -106,8 +106,8 @@ mixin $ExampleFormView on StatelessWidget {
     }
   }
 
-  /// Updates the fieldsValidationMessages on the FormViewModel
-  void _updateValidationData(FormViewModel model) =>
+  /// Updates the fieldsValidationMessages on the FormStateHelper
+  void _updateValidationData(FormStateHelper model) =>
       model.setValidationMessages({
         EmailValueKey: _getValidationMessage(EmailValueKey),
         PasswordValueKey: _getValidationMessage(PasswordValueKey),
@@ -139,7 +139,7 @@ mixin $ExampleFormView on StatelessWidget {
   }
 }
 
-extension ValueProperties on FormViewModel {
+extension ValueProperties on FormStateHelper {
   bool get isFormValid =>
       this.fieldsValidationMessages.values.every((element) => element == null);
   String? get emailValue => this.formValueMap[EmailValueKey] as String?;
@@ -180,7 +180,7 @@ extension ValueProperties on FormViewModel {
       this.fieldsValidationMessages[DoYouLoveFoodValueKey];
 }
 
-extension Methods on FormViewModel {
+extension Methods on FormStateHelper {
   Future<void> selectBirthDate(
       {required BuildContext context,
       required DateTime initialDate,

--- a/packages/stacked/example/lib/ui/form/example_form_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_viewmodel.dart
@@ -8,7 +8,7 @@ import '../../app/app.locator.dart';
 import 'example_form_view.form.dart';
 
 // #5: extend from FormViewModel
-class ExampleFormViewModel extends FormViewModel {
+class ExampleFormViewModel extends BaseViewModel with FormStateHelper {
   final log = getLogger('FormViewModel');
   final _navigationService = exampleLocator<NavigationService>();
 

--- a/packages/stacked/example/lib/ui/home/home_view.dart
+++ b/packages/stacked/example/lib/ui/home/home_view.dart
@@ -23,6 +23,7 @@ class HomeView extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               Text(viewModel.title),
+              if (viewModel.hasMessage) Text(viewModel.modelMessage!),
               const SizedBox(height: 20),
               Row(
                 mainAxisSize: MainAxisSize.min,

--- a/packages/stacked/example/lib/ui/home/home_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/home/home_viewmodel.dart
@@ -4,7 +4,7 @@ import 'package:example/app/app.router.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
-class HomeViewModel extends BaseViewModel {
+class HomeViewModel extends BaseViewModel with MessageStateHelper {
   final log = getLogger('HomeViewModel');
   final NavigationService _navigationService =
       exampleLocator<NavigationService>();
@@ -17,6 +17,7 @@ class HomeViewModel extends BaseViewModel {
   }
 
   void initialise() {
+    setMessage('initialise');
     log.i('initialise');
     title = 'Initialised';
     notifyListeners();

--- a/packages/stacked/example/lib/ui/smart_widgets/widget_one/widget_one_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/smart_widgets/widget_one/widget_one_viewmodel.dart
@@ -2,7 +2,8 @@ import 'package:example/app/app.locator.dart';
 import 'package:example/services/information_service.dart';
 import 'package:stacked/stacked.dart';
 
-class WidgetOneViewModel extends ReactiveViewModel {
+class WidgetOneViewModel extends ReactiveViewModel
+    with BusyStateHelper, ErrorStateHelper, FutureRunnerHelper {
   final InformationService _informationService =
       exampleLocator<InformationService>();
   int get postCount => _informationService.postCount;

--- a/packages/stacked/example/lib/ui/smart_widgets/widget_one/widget_one_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/smart_widgets/widget_one/widget_one_viewmodel.dart
@@ -2,8 +2,7 @@ import 'package:example/app/app.locator.dart';
 import 'package:example/services/information_service.dart';
 import 'package:stacked/stacked.dart';
 
-class WidgetOneViewModel extends ReactiveViewModel
-    with BusyStateHelper, ErrorStateHelper, FutureRunnerHelper {
+class WidgetOneViewModel extends ReactiveViewModel with FutureRunnerHelper {
   final InformationService _informationService =
       exampleLocator<InformationService>();
   int get postCount => _informationService.postCount;

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -80,17 +80,14 @@ abstract class ReactiveViewModel extends BaseViewModel {
 }
 
 @protected
-class DynamicSourceViewModel<T> extends ReactiveViewModel {
+class DynamicSourceViewModel<T> extends BaseViewModel {
   bool changeSource = false;
-  void notifySourceChanged({bool clearOldData = false}) {
+  void notifySourceChanged() {
     changeSource = true;
   }
-
-  @override
-  List<ReactiveServiceMixin> get reactiveServices => [];
 }
 
-class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel {
+class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel<T> {
   T? _data;
   T? get data => _data;
 
@@ -336,7 +333,7 @@ abstract class MultipleStreamViewModel extends _MultiDataSourceViewModel
 
 abstract class StreamViewModel<T> extends _SingleDataSourceViewModel<T>
     with MessageStateHelper
-    implements DynamicSourceViewModel, Initialisable {
+    implements DynamicSourceViewModel<T>, Initialisable {
   /// Stream to listen to
   Stream<T> get stream;
 

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -144,10 +144,6 @@ class _MultiDataSourceViewModel<K extends Object> extends DynamicSourceViewModel
 abstract class FutureViewModel<T> extends _SingleDataSourceViewModel<T>
     with MessageStateHelper, BusyStateHelper, FutureRunnerHelper
     implements Initialisable {
-  /// The future that fetches the data and sets the view to busy
-  @Deprecated('Use the futureToRun function')
-  Future<T>? get future => null;
-
   // TODO: Add timeout functionality
   // TODO: Add retry functionality - default 1
   // TODO: Add retry lifecycle hooks to override in the viewmodel

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:stacked/src/state_management/reactive_service_mixin.dart';
 
 import 'helpers/builders_helpers.dart';
 import 'helpers/busy_state_helper.dart';
 import 'helpers/error_state_helper.dart';
-import 'helpers/future_runner_helper.dart';
 import 'helpers/message_state_helper.dart';
 
 /// Contains ViewModel functionality for busy state management
@@ -87,331 +86,12 @@ class DynamicSourceViewModel<T> extends BaseViewModel {
   }
 }
 
-class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel<T> {
-  T? _data;
-  T? get data => _data;
-
-  dynamic _error;
-
-  @override
-  dynamic error([Object? object]) => _error;
-  @override
-  void setError(error) {
-    _error = error;
-    super.setError(error);
-  }
-
-  bool get hasError => error(this) != null;
-  bool get dataReady => _data != null && !hasError;
+/// Interface: Additional actions that should be implemented by spcialised ViewModels
+abstract class Initialisable {
+  void initialise();
 }
 
-class _MultiDataSourceViewModel<K extends Object>
-    extends DynamicSourceViewModel {
-  Map<K, dynamic>? _dataMap;
-  Map<K, dynamic>? get dataMap => _dataMap;
-
-  bool dataReady(K key) => _dataMap![key] != null && (error(key) == null);
-}
-
-/// Provides functionality for a ViewModel that's sole purpose it is to fetch data using a [Future]
-abstract class FutureViewModel<T> extends _SingleDataSourceViewModel<T>
-    with MessageStateHelper, FutureRunnerHelper
-    implements Initialisable {
-  // TODO: Add timeout functionality
-  // TODO: Add retry functionality - default 1
-  // TODO: Add retry lifecycle hooks to override in the viewmodel
-
-  /// The future that fetches the data and sets the view to busy
-  Future<T> futureToRun();
-
-  /// Indicates if you want the error caught in futureToRun to be rethrown
-  bool get rethrowException => false;
-
-  Future initialise() async {
-    setError(null);
-    setMessage(null);
-    _error = null;
-    // We set busy manually as well because when notify listeners is called to clear error messages the
-    // ui is rebuilt and if you expect busy to be true it's not.
-    setBusy(true);
-    notifyListeners();
-
-    _data = await runBusyFuture<T?>(futureToRun(), throwException: true)
-        .catchError((error) {
-      setError(error);
-      _error = error;
-      setBusy(false);
-      onError(error);
-      notifyListeners();
-      if (rethrowException) {
-        throw error;
-      }
-
-      return null;
-    });
-
-    if (_data != null) {
-      onData(_data);
-    }
-
-    changeSource = false;
-  }
-
-  /// Called when an error occurs within the future being run
-  void onError(error) {}
-
-  /// Called after the data has been set
-  void onData(T? data) {}
-}
-
-/// Provides functionality for a ViewModel to run and fetch data using multiple future
-abstract class MultipleFutureViewModel extends _MultiDataSourceViewModel
-    with FutureRunnerHelper
-    implements Initialisable {
-  Map<String, Future Function()> get futuresMap;
-
-  late Completer _futuresCompleter;
-  late int _futuresCompleted;
-
-  void _initialiseData() {
-    if (_dataMap == null) {
-      _dataMap = Map<String, dynamic>();
-    }
-
-    _futuresCompleted = 0;
-  }
-
-  Future initialise() {
-    _futuresCompleter = Completer();
-    _initialiseData();
-    // We set busy manually as well because when notify listeners is called to clear error messages the
-    // ui is rebuilt and if you expect busy to be true it's not.
-    setBusy(true);
-    notifyListeners();
-
-    for (var key in futuresMap.keys) {
-      runBusyFuture(futuresMap[key]!(), busyObject: key, throwException: true)
-          .then((futureData) {
-        _dataMap![key] = futureData;
-        setBusyForObject(key, false);
-        notifyListeners();
-        onData(key);
-        _incrementAndCheckFuturesCompleted();
-      }).catchError((error) {
-        setErrorForObject(key, error);
-        setBusyForObject(key, false);
-        onError(key: key, error: error);
-        notifyListeners();
-        _incrementAndCheckFuturesCompleted();
-      });
-    }
-    setBusy(false);
-    changeSource = false;
-
-    return _futuresCompleter.future;
-  }
-
-  void _incrementAndCheckFuturesCompleted() {
-    _futuresCompleted++;
-    if (_futuresCompleted == futuresMap.length &&
-        !_futuresCompleter.isCompleted) {
-      _futuresCompleter.complete();
-    }
-  }
-
-  void onError({String? key, error}) {}
-
-  void onData(String key) {}
-}
-
-/// Provides functionality for a ViewModel to run and fetch data using multiple streams
-abstract class MultipleStreamViewModel extends _MultiDataSourceViewModel
-    implements Initialisable {
-  // Every MultipleStreamViewModel must override streamDataMap
-  // StreamData requires a stream, but lifecycle events are optional
-  // if a lifecyle event isn't defined we use the default ones here
-  Map<String, StreamData> get streamsMap;
-
-  Map<String, StreamSubscription>? _streamsSubscriptions;
-
-  @visibleForTesting
-  Map<String, StreamSubscription>? get streamsSubscriptions =>
-      _streamsSubscriptions;
-
-  /// Returns the stream subscription associated with the key
-  StreamSubscription? getSubscriptionForKey(String key) =>
-      _streamsSubscriptions![key];
-
-  void initialise() {
-    _dataMap = Map<String, dynamic>();
-    clearErrors();
-    _streamsSubscriptions = Map<String, StreamSubscription>();
-
-    if (!changeSource) {
-      notifyListeners();
-    }
-    final _streamsMapValues = Map<String, StreamData>.from(streamsMap);
-
-    for (final key in _streamsMapValues.keys) {
-      // If a lifecycle function isn't supplied, we fallback to default
-      _streamsSubscriptions![key] = _streamsMapValues[key]!.stream.listen(
-        (incomingData) {
-          setErrorForObject(key, null);
-          notifyListeners();
-          // Extra security in case transformData isnt sent
-          var interceptedData = _streamsMapValues[key]!.transformData == null
-              ? transformData(key, incomingData)
-              : _streamsMapValues[key]!.transformData!(incomingData);
-
-          if (interceptedData != null) {
-            _dataMap![key] = interceptedData;
-          } else {
-            _dataMap![key] = incomingData;
-          }
-
-          notifyListeners();
-          _streamsMapValues[key]!.onData != null
-              ? _streamsMapValues[key]!.onData!(_dataMap![key])
-              : onData(key, _dataMap![key]);
-        },
-        onError: (error) {
-          setErrorForObject(key, error);
-          _dataMap![key] = null;
-
-          _streamsMapValues[key]!.onError != null
-              ? _streamsMapValues[key]!.onError!(error)
-              : onError(key, error);
-          notifyListeners();
-        },
-      );
-      _streamsMapValues[key]!.onSubscribed != null
-          ? _streamsMapValues[key]!.onSubscribed!()
-          : onSubscribed(key);
-      changeSource = false;
-    }
-  }
-
-  @override
-  void notifySourceChanged({bool clearOldData = false}) {
-    changeSource = true;
-    _disposeAllSubscriptions();
-
-    if (clearOldData) {
-      dataMap!.clear();
-      clearErrors();
-    }
-
-    notifyListeners();
-  }
-
-  void onData(String key, dynamic data) {}
-  void onSubscribed(String key) {}
-  void onError(String key, error) {}
-  void onCancel(String key) {}
-  dynamic transformData(String key, data) {
-    return data;
-  }
-
-  @override
-  @mustCallSuper
-  void dispose() {
-    _disposeAllSubscriptions();
-    super.dispose();
-  }
-
-  void _disposeAllSubscriptions() {
-    if (_streamsSubscriptions != null) {
-      for (var key in _streamsSubscriptions!.keys) {
-        _streamsSubscriptions![key]!.cancel();
-        onCancel(key);
-      }
-
-      _streamsSubscriptions!.clear();
-    }
-  }
-}
-
-abstract class StreamViewModel<T> extends _SingleDataSourceViewModel<T>
-    with MessageStateHelper
-    implements DynamicSourceViewModel<T>, Initialisable {
-  /// Stream to listen to
-  Stream<T> get stream;
-
-  StreamSubscription? get streamSubscription => _streamSubscription;
-
-  StreamSubscription? _streamSubscription;
-
-  @override
-  void notifySourceChanged({bool clearOldData = false}) {
-    changeSource = true;
-    _streamSubscription?.cancel();
-    _streamSubscription = null;
-
-    if (clearOldData) {
-      _data = null;
-    }
-
-    notifyListeners();
-  }
-
-  void initialise() {
-    _streamSubscription = stream.listen(
-      (incomingData) {
-        setError(null);
-        setMessage(null);
-        _error = null;
-        notifyListeners();
-        // Extra security in case transformData isnt sent
-        var interceptedData = transformData(incomingData);
-
-        if (interceptedData != null) {
-          _data = interceptedData;
-        } else {
-          _data = incomingData;
-        }
-
-        onData(_data);
-        notifyListeners();
-      },
-      onError: (error) {
-        setError(error);
-        _error = error;
-        _data = null;
-        onError(error);
-        notifyListeners();
-      },
-    );
-
-    onSubscribed();
-    changeSource = false;
-  }
-
-  /// Called before the notifyListeners is called when data has been set
-  void onData(T? data) {}
-
-  /// Called when the stream is listened too
-  void onSubscribed() {}
-
-  /// Called when an error is fired in the stream
-  void onError(error) {}
-
-  void onCancel() {}
-
-  /// Called before the data is set for the ViewModel
-  T transformData(T data) {
-    return data;
-  }
-
-  @override
-  void dispose() {
-    _streamSubscription!.cancel();
-    onCancel();
-
-    super.dispose();
-  }
-}
-
-class StreamData<T> extends _SingleDataSourceViewModel<T>
+class StreamData<T> extends SingleDataSourceViewModel<T>
     with MessageStateHelper {
   Stream<T> stream;
 
@@ -485,7 +165,15 @@ class StreamData<T> extends _SingleDataSourceViewModel<T>
   }
 }
 
-/// Interface: Additional actions that should be implemented by spcialised ViewModels
-abstract class Initialisable {
-  void initialise();
+class SingleDataSourceViewModel<T> extends DynamicSourceViewModel<T> {
+  dynamic _error;
+  @override
+  dynamic error([Object? object]) => _error;
+  @override
+  void setError(error) {
+    _error = error;
+    super.setError(error);
+  }
+
+  bool get hasError => error(this) != null;
 }

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -3,38 +3,15 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:stacked/src/state_management/reactive_service_mixin.dart';
 
+import 'helpers/builders_helpers.dart';
 import 'helpers/busy_state_helper.dart';
 import 'helpers/error_state_helper.dart';
 import 'helpers/future_runner_helper.dart';
 import 'helpers/message_state_helper.dart';
 
-mixin _InitialisableHelper {
-  bool _initialised = false;
-  bool get initialised => _initialised;
-
-  /// Sets the initialised value for the ViewModel to true. This is called after
-  /// the first initialise special ViewModel call
-  void setInitialised(bool value) {
-    _initialised = value;
-  }
-}
-mixin _ModalReadyHelper {
-  bool _onModelReadyCalled = false;
-  bool get onModelReadyCalled => _onModelReadyCalled;
-
-  /// Sets the onModelReadyCalled value to true. This is called after this first onModelReady call
-  void setOnModelReadyCalled(bool value) {
-    _onModelReadyCalled = value;
-  }
-}
-mixin _DisposableHelper {
-  bool _disposed = false;
-  bool get disposed => _disposed;
-}
-
 /// Contains ViewModel functionality for busy state management
 class BaseViewModel extends ChangeNotifier
-    with _DisposableHelper, _ModalReadyHelper, _InitialisableHelper {
+    with BuilderHelpers, BusyStateHelper, ErrorStateHelper {
   // Sets up streamData property to hold data, busy, and lifecycle events
   @protected
   StreamData setupStream<T>(
@@ -67,7 +44,7 @@ class BaseViewModel extends ChangeNotifier
 
   @override
   void dispose() {
-    _disposed = true;
+    disposed = true;
     super.dispose();
   }
 }
@@ -113,8 +90,7 @@ class DynamicSourceViewModel<T> extends ReactiveViewModel {
   List<ReactiveServiceMixin> get reactiveServices => [];
 }
 
-class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel
-    with ErrorStateHelper {
+class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel {
   T? _data;
   T? get data => _data;
 
@@ -132,8 +108,8 @@ class _SingleDataSourceViewModel<T> extends DynamicSourceViewModel
   bool get dataReady => _data != null && !hasError;
 }
 
-class _MultiDataSourceViewModel<K extends Object> extends DynamicSourceViewModel
-    with ErrorStateHelper {
+class _MultiDataSourceViewModel<K extends Object>
+    extends DynamicSourceViewModel {
   Map<K, dynamic>? _dataMap;
   Map<K, dynamic>? get dataMap => _dataMap;
 
@@ -142,7 +118,7 @@ class _MultiDataSourceViewModel<K extends Object> extends DynamicSourceViewModel
 
 /// Provides functionality for a ViewModel that's sole purpose it is to fetch data using a [Future]
 abstract class FutureViewModel<T> extends _SingleDataSourceViewModel<T>
-    with MessageStateHelper, BusyStateHelper, FutureRunnerHelper
+    with MessageStateHelper, FutureRunnerHelper
     implements Initialisable {
   // TODO: Add timeout functionality
   // TODO: Add retry functionality - default 1
@@ -193,7 +169,7 @@ abstract class FutureViewModel<T> extends _SingleDataSourceViewModel<T>
 
 /// Provides functionality for a ViewModel to run and fetch data using multiple future
 abstract class MultipleFutureViewModel extends _MultiDataSourceViewModel
-    with BusyStateHelper, FutureRunnerHelper
+    with FutureRunnerHelper
     implements Initialisable {
   Map<String, Future Function()> get futuresMap;
 

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -3,12 +3,60 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:stacked/src/state_management/reactive_service_mixin.dart';
 
-/// Contains ViewModel functionality for busy state management
-class BaseViewModel extends ChangeNotifier {
+mixin BusyState on ChangeNotifier {
   Map<int, bool> _busyStates = Map<int, bool>();
+
+  /// Returns the busy status for an object if it exists. Returns false if not present
+  bool busy(Object? object) => _busyStates[object.hashCode] ?? false;
+
+  /// Returns the busy status of the ViewModel
+  bool get isBusy => busy(this);
+
+  // Returns true if any objects still have a busy status that is true.
+  bool get anyObjectsBusy => _busyStates.values.any((busy) => busy);
+}
+
+mixin ErrorState on ChangeNotifier {
   Map<int, dynamic> _errorStates = Map<int, dynamic>();
+  dynamic error(Object object) => _errorStates[object.hashCode];
+
+  /// Returns the error existence status of the ViewModel
+  bool get hasError => error(this) != null;
+
+  /// Returns the error status of the ViewModel
+  dynamic get modelError => error(this);
+
+  /// Clears all the errors
+  void clearErrors() {
+    _errorStates.clear();
+  }
+
+  /// Returns a boolean that indicates if the ViewModel has an error for the key
+  bool hasErrorForKey(Object key) => error(key) != null;
+}
+mixin MessageState on ChangeNotifier {
   Map<int, String?> _messageStates = Map<int, String?>();
 
+  /// Returns the message for an object if it exists. Returns null if not present
+  String? message(Object object) => _messageStates[object.hashCode];
+
+  /// Returns the message status of the ViewModel
+  bool get hasMessage => message(this) != null;
+
+  /// Returns the message status of the ViewModel
+  String? get modelMessage => message(this);
+
+  /// Returns a boolean that indicates if the ViewModel has an message for the key
+  bool hasMessageForKey(Object key) => message(key) != null;
+
+  void clearMessages() {
+    _messageStates.clear();
+  }
+}
+
+/// Contains ViewModel functionality for busy state management
+class BaseViewModel extends ChangeNotifier
+    with BusyState, ErrorState, MessageState {
   bool _initialised = false;
   bool get initialised => _initialised;
 
@@ -17,32 +65,6 @@ class BaseViewModel extends ChangeNotifier {
 
   bool _disposed = false;
   bool get disposed => _disposed;
-
-  /// Returns the busy status for an object if it exists. Returns false if not present
-  bool busy(Object? object) => _busyStates[object.hashCode] ?? false;
-
-  dynamic error(Object object) => _errorStates[object.hashCode];
-
-  /// Returns the message for an object if it exists. Returns null if not present
-  String? message(Object object) => _messageStates[object.hashCode];
-
-  /// Returns the busy status of the ViewModel
-  bool get isBusy => busy(this);
-
-  /// Returns the error existence status of the ViewModel
-  bool get hasError => error(this) != null;
-
-  /// Returns the error status of the ViewModel
-  dynamic get modelError => error(this);
-
-  /// Returns the message status of the ViewModel
-  bool get hasMessage => message(this) != null;
-
-  /// Returns the message status of the ViewModel
-  String? get modelMessage => message(this);
-
-  // Returns true if any objects still have a busy status that is true.
-  bool get anyObjectsBusy => _busyStates.values.any((busy) => busy);
 
   /// Marks the ViewModel as busy and calls notify listeners
   void setBusy(bool value) {
@@ -70,21 +92,6 @@ class BaseViewModel extends ChangeNotifier {
     else if (!isBusyKeySupplied && isBusy) return busyData;
 
     return realData;
-  }
-
-  /// Returns a boolean that indicates if the ViewModel has an error for the key
-  bool hasErrorForKey(Object key) => error(key) != null;
-
-  /// Returns a boolean that indicates if the ViewModel has an message for the key
-  bool hasMessageForKey(Object key) => message(key) != null;
-
-  /// Clears all the errors
-  void clearErrors() {
-    _errorStates.clear();
-  }
-
-  void clearMessages() {
-    _messageStates.clear();
   }
 
   /// Sets the busy state for the object equal to the value passed in and notifies Listeners

--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -12,29 +12,6 @@ import 'helpers/message_state_helper.dart';
 /// Contains ViewModel functionality for busy and error state management
 class BaseViewModel extends ChangeNotifier
     with BuilderHelpers, BusyStateHelper, ErrorStateHelper {
-  // Sets up streamData property to hold data, busy, and lifecycle events
-  @protected
-  StreamData setupStream<T>(
-    Stream<T> stream, {
-    onData,
-    onSubscribed,
-    onError,
-    onCancel,
-    transformData,
-  }) {
-    StreamData<T> streamData = StreamData<T>(
-      stream,
-      onData: onData,
-      onSubscribed: onSubscribed,
-      onError: onError,
-      onCancel: onCancel,
-      transformData: transformData,
-    );
-    streamData.initialise();
-
-    return streamData;
-  }
-
   @override
   void notifyListeners() {
     if (!disposed) {

--- a/packages/stacked/lib/src/state_management/form_view_model.dart
+++ b/packages/stacked/lib/src/state_management/form_view_model.dart
@@ -1,0 +1,56 @@
+import 'package:stacked/src/state_management/base_view_models.dart';
+import 'package:stacked/src/state_management/reactive_service_mixin.dart';
+
+/// Provides functionality to reduce the code required in order to move user input
+/// into the [ViewModel]
+@Deprecated(
+    'This class will be removed in the future, Use [BaseViewModel] or [ReactiveViewModel] with a [FormStateHelper] instead')
+abstract class FormViewModel extends ReactiveViewModel {
+  @override
+  List<ReactiveServiceMixin> get reactiveServices => [];
+
+  bool _showValidationMessage = false;
+  bool get showValidationMessage => _showValidationMessage;
+
+  String? _validationMessage;
+  String? get validationMessage => _validationMessage;
+
+  /// Stores the mapping of the form key to the value entered by the user
+  Map<String, dynamic> formValueMap = Map<String, dynamic>();
+  Map<String, String?> fieldsValidationMessages = Map<String, String?>();
+
+  void setValidationMessage(String? value) {
+    _validationMessage = value;
+    _showValidationMessage = _validationMessage?.isNotEmpty ?? false;
+  }
+
+  void setData(Map<String, dynamic> data) {
+    // Save the data from the controllers
+    formValueMap = data;
+
+    // Reset the form status
+    setValidationMessage(null);
+
+    // Reset each field status
+    for (var fieldName in data.keys) {
+      fieldsValidationMessages.remove(fieldName);
+    }
+
+    // Set the new form status
+    setFormStatus();
+
+    // Rebuild the UI
+    notifyListeners();
+  }
+
+  void setValidationMessages(Map<String, String?> validationMessages) {
+    fieldsValidationMessages = validationMessages;
+    fieldsValidationMessages.removeWhere((key, value) => value == null);
+    setFormStatus();
+    notifyListeners();
+  }
+
+  /// Called after the [formValueMap] has been updated and allows you to set
+  /// values relating to the forms status.
+  void setFormStatus();
+}

--- a/packages/stacked/lib/src/state_management/helpers/builders_helpers.dart
+++ b/packages/stacked/lib/src/state_management/helpers/builders_helpers.dart
@@ -1,0 +1,21 @@
+/// Essential helper to work with the [ViewModelBuilder]
+mixin BuilderHelpers {
+  bool disposed = false;
+
+  bool _initialised = false;
+  bool get initialised => _initialised;
+
+  bool _onModelReadyCalled = false;
+  bool get onModelReadyCalled => _onModelReadyCalled;
+
+  /// Sets the initialised value for the ViewModel to true. This is called after
+  /// the first initialise special ViewModel call
+  void setInitialised(bool value) {
+    _initialised = value;
+  }
+
+  /// Sets the onModelReadyCalled value to true. This is called after this first onModelReady call
+  void setOnModelReadyCalled(bool value) {
+    _onModelReadyCalled = value;
+  }
+}

--- a/packages/stacked/lib/src/state_management/helpers/busy_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/busy_state_helper.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+mixin BusyStateHelper on ChangeNotifier {
+  Map<int, bool> _busyStates = Map<int, bool>();
+
+  /// Returns the busy status for an object if it exists. Returns false if not present
+  bool busy(Object? object) => _busyStates[object.hashCode] ?? false;
+
+  /// Returns the busy status of the ViewModel
+  bool get isBusy => busy(this);
+
+  // Returns true if any objects still have a busy status that is true.
+  bool get anyObjectsBusy => _busyStates.values.any((busy) => busy);
+
+  /// Sets the busy state for the object equal to the value passed in and notifies Listeners
+  /// If you're using a primitive type the value SHOULD NOT BE CHANGED, since Hashcode uses == value
+  void setBusyForObject(Object? object, bool value) {
+    _busyStates[object.hashCode] = value;
+    notifyListeners();
+  }
+
+  /// Marks the ViewModel as busy and calls notify listeners
+  void setBusy(bool value) {
+    setBusyForObject(this, value);
+  }
+
+  /// returns real data passed if neither the model is busy nor the object passed is busy
+  T skeletonData<T>(
+      {required T? realData, required T busyData, Object? busyKey}) {
+    /// If busyKey is supplied we check busy(busyKey) to see if that property is busy
+    /// If it is we return busyData, else realData
+    bool isBusyKeySupplied = busyKey != null;
+    if ((isBusyKeySupplied && busy(busyKey)) || realData == null)
+      return busyData;
+    else if (!isBusyKeySupplied && isBusy) return busyData;
+
+    return realData;
+  }
+}

--- a/packages/stacked/lib/src/state_management/helpers/data_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/data_state_helper.dart
@@ -1,0 +1,13 @@
+import 'package:stacked/src/state_management/helpers/error_state_helper.dart';
+
+mixin DataStateHelper<T> on ErrorStateHelper {
+  T? _data;
+
+  T? get data => _data;
+
+  set data(T? data) {
+    _data = data;
+  }
+
+  bool get dataReady => _data != null && !hasError;
+}

--- a/packages/stacked/lib/src/state_management/helpers/data_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/data_state_helper.dart
@@ -1,6 +1,8 @@
+import 'package:stacked/src/state_management/helpers/busy_state_helper.dart';
 import 'package:stacked/src/state_management/helpers/error_state_helper.dart';
 
-mixin DataStateHelper<T> on ErrorStateHelper {
+/// Helper class to store a data object
+mixin DataStateHelper<T> on ErrorStateHelper, BusyStateHelper {
   T? _data;
 
   T? get data => _data;
@@ -9,5 +11,6 @@ mixin DataStateHelper<T> on ErrorStateHelper {
     _data = data;
   }
 
-  bool get dataReady => _data != null && !hasError;
+  /// Data is ready to be consumed
+  bool get dataReady => _data != null && !hasError && !isBusy;
 }

--- a/packages/stacked/lib/src/state_management/helpers/error_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/error_state_helper.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/foundation.dart';
+
+mixin ErrorStateHelper on ChangeNotifier {
+  Map<int, dynamic> _errorStates = Map<int, dynamic>();
+  dynamic error(Object object) => _errorStates[object.hashCode];
+
+  /// Returns the error existence status of the ViewModel
+  bool get hasError => error(this) != null;
+
+  /// Returns the error status of the ViewModel
+  dynamic get modelError => error(this);
+
+  /// Clears all the errors
+  void clearErrors() {
+    _errorStates.clear();
+  }
+
+  /// Returns a boolean that indicates if the ViewModel has an error for the key
+  bool hasErrorForKey(Object key) => error(key) != null;
+
+  /// Sets the error for the ViewModel
+  void setError(dynamic error) {
+    setErrorForObject(this, error);
+  }
+
+  void setErrorForModelOrObject(dynamic value, {Object? key}) {
+    if (key != null) {
+      setErrorForObject(key, value);
+    } else {
+      setErrorForObject(this, value);
+    }
+  }
+
+  /// Sets the error state for the object equal to the value passed in and notifies Listeners
+  /// If you're using a primitive type the value SHOULD NOT BE CHANGED, since Hashcode uses == value
+  void setErrorForObject(Object object, dynamic value) {
+    _errorStates[object.hashCode] = value;
+    notifyListeners();
+  }
+}

--- a/packages/stacked/lib/src/state_management/helpers/form_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/form_state_helper.dart
@@ -1,12 +1,8 @@
-import 'package:stacked/src/state_management/base_view_models.dart';
-import 'package:stacked/src/state_management/reactive_service_mixin.dart';
+import 'package:flutter/material.dart';
 
 /// Provides functionality to reduce the code required in order to move user input
 /// into the [ViewModel]
-abstract class FormViewModel extends ReactiveViewModel {
-  @override
-  List<ReactiveServiceMixin> get reactiveServices => [];
-
+mixin FormStateHelper on ChangeNotifier {
   bool _showValidationMessage = false;
   bool get showValidationMessage => _showValidationMessage;
 

--- a/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
@@ -1,0 +1,49 @@
+import 'busy_state_helper.dart';
+import 'error_state_helper.dart';
+
+/// [FutureRunnerHelper] depends on [ErrorStateHelper] and [BusyStateHelper] to reflect the result of
+/// the future into the view model, you have to add [ErrorStateHelper], [BusyStateHelper] mixins
+/// before you can add the [FutureRunnerHelper] mixin.
+mixin FutureRunnerHelper on ErrorStateHelper, BusyStateHelper {
+  /// Sets the ViewModel to busy, runs the future and then sets it to not busy when complete.
+  ///
+  /// rethrows [Exception] after setting busy to false for object or class
+  Future<T> runBusyFuture<T>(Future<T> busyFuture,
+      {Object? busyObject, bool throwException = false}) async {
+    _setBusyForModelOrObject(true, busyObject: busyObject);
+    try {
+      var value = await runErrorFuture<T>(busyFuture,
+          key: busyObject, throwException: throwException);
+      return value;
+    } catch (e) {
+      if (throwException) rethrow;
+      return Future.value();
+    } finally {
+      _setBusyForModelOrObject(false, busyObject: busyObject);
+    }
+  }
+
+  Future<T> runErrorFuture<T>(Future<T> future,
+      {Object? key, bool throwException = false}) async {
+    try {
+      setErrorForModelOrObject(null, key: key);
+      return await future;
+    } catch (e) {
+      setErrorForModelOrObject(e, key: key);
+      onFutureError(e, key);
+      if (throwException) rethrow;
+      return Future.value();
+    }
+  }
+
+  /// Function that is called when a future throws an error
+  void onFutureError(dynamic error, Object? key) {}
+
+  void _setBusyForModelOrObject(bool value, {Object? busyObject}) {
+    if (busyObject != null) {
+      setBusyForObject(busyObject, value);
+    } else {
+      setBusyForObject(this, value);
+    }
+  }
+}

--- a/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
@@ -1,10 +1,12 @@
+import 'package:stacked/stacked.dart';
+
 import 'busy_state_helper.dart';
 import 'error_state_helper.dart';
 
 /// [FutureRunnerHelper] depends on [ErrorStateHelper] and [BusyStateHelper] to reflect the result of
 /// the future into the view model, you have to add [ErrorStateHelper], [BusyStateHelper] mixins
 /// before you can add the [FutureRunnerHelper] mixin.
-mixin FutureRunnerHelper on ErrorStateHelper, BusyStateHelper {
+mixin FutureRunnerHelper on BaseViewModel {
   /// Sets the ViewModel to busy, runs the future and then sets it to not busy when complete.
   ///
   /// rethrows [Exception] after setting busy to false for object or class

--- a/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/future_runner_helper.dart
@@ -1,12 +1,10 @@
-import 'package:stacked/stacked.dart';
-
 import 'busy_state_helper.dart';
 import 'error_state_helper.dart';
 
 /// [FutureRunnerHelper] depends on [ErrorStateHelper] and [BusyStateHelper] to reflect the result of
 /// the future into the view model, you have to add [ErrorStateHelper], [BusyStateHelper] mixins
 /// before you can add the [FutureRunnerHelper] mixin.
-mixin FutureRunnerHelper on BaseViewModel {
+mixin FutureRunnerHelper on ErrorStateHelper, BusyStateHelper {
   /// Sets the ViewModel to busy, runs the future and then sets it to not busy when complete.
   ///
   /// rethrows [Exception] after setting busy to false for object or class

--- a/packages/stacked/lib/src/state_management/helpers/index_tracking_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/index_tracking_state_helper.dart
@@ -1,7 +1,6 @@
-import 'package:stacked/src/state_management/base_view_models.dart';
-import 'package:stacked/src/state_management/reactive_service_mixin.dart';
+import 'package:flutter/material.dart';
 
-class IndexTrackingViewModel extends ReactiveViewModel {
+mixin IndexTrackingStateHelper on ChangeNotifier {
   int _currentIndex = 0;
   int get currentIndex => _currentIndex;
 
@@ -22,7 +21,4 @@ class IndexTrackingViewModel extends ReactiveViewModel {
   }
 
   bool isIndexSelected(int index) => _currentIndex == index;
-
-  @override
-  List<ReactiveServiceMixin> get reactiveServices => [];
 }

--- a/packages/stacked/lib/src/state_management/helpers/message_state_helper.dart
+++ b/packages/stacked/lib/src/state_management/helpers/message_state_helper.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+mixin MessageStateHelper on ChangeNotifier {
+  Map<int, String?> _messageStates = Map<int, String?>();
+
+  /// Returns the message for an object if it exists. Returns null if not present
+  String? message(Object object) => _messageStates[object.hashCode];
+
+  /// Returns the message status of the ViewModel
+  bool get hasMessage => message(this) != null;
+
+  /// Returns the message status of the ViewModel
+  String? get modelMessage => message(this);
+
+  /// Returns a boolean that indicates if the ViewModel has an message for the key
+  bool hasMessageForKey(Object key) => message(key) != null;
+
+  void clearMessages() {
+    _messageStates.clear();
+  }
+
+  /// Sets the message for the ViewModel
+  void setMessage(String? message) {
+    setMessageForObject(this, message);
+  }
+
+  /// Sets the message for the object equal to the value passed in and notifies Listeners
+  /// If you're using a primitive type the value SHOULD NOT BE CHANGED, since Hashcode uses == value
+  void setMessageForObject(Object object, String? value) {
+    _messageStates[object.hashCode] = value;
+    notifyListeners();
+  }
+}

--- a/packages/stacked/lib/src/state_management/index_tracking_viewmodel.dart
+++ b/packages/stacked/lib/src/state_management/index_tracking_viewmodel.dart
@@ -1,0 +1,30 @@
+import 'package:stacked/src/state_management/base_view_models.dart';
+import 'package:stacked/src/state_management/reactive_service_mixin.dart';
+
+@Deprecated(
+    'This class will be removed in the future, Use [BaseViewModel] or [ReactiveViewModel] with a [IndexTrackingStateHelper] instead')
+class IndexTrackingViewModel extends ReactiveViewModel {
+  int _currentIndex = 0;
+  int get currentIndex => _currentIndex;
+
+  bool _reverse = false;
+
+  /// Indicates whether we're going forward or backward in terms of the index we're changing.
+  /// This is very helpful for the page transition directions.
+  bool get reverse => _reverse;
+
+  void setIndex(int value) {
+    if (value < _currentIndex) {
+      _reverse = true;
+    } else {
+      _reverse = false;
+    }
+    _currentIndex = value;
+    notifyListeners();
+  }
+
+  bool isIndexSelected(int index) => _currentIndex == index;
+
+  @override
+  List<ReactiveServiceMixin> get reactiveServices => [];
+}

--- a/packages/stacked/lib/src/state_management/multiple_data_models.dart
+++ b/packages/stacked/lib/src/state_management/multiple_data_models.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'base_view_models.dart';
+import 'helpers/future_runner_helper.dart';
+
+class _MultiDataSourceViewModel<K extends Object>
+    extends DynamicSourceViewModel {
+  Map<K, dynamic>? _dataMap;
+  Map<K, dynamic>? get dataMap => _dataMap;
+
+  bool dataReady(K key) => _dataMap![key] != null && (error(key) == null);
+}
+
+/// Provides functionality for a ViewModel to run and fetch data using multiple future
+abstract class MultipleFutureViewModel extends _MultiDataSourceViewModel
+    with FutureRunnerHelper
+    implements Initialisable {
+  Map<String, Future Function()> get futuresMap;
+
+  late Completer _futuresCompleter;
+  late int _futuresCompleted;
+
+  void _initialiseData() {
+    if (_dataMap == null) {
+      _dataMap = Map<String, dynamic>();
+    }
+
+    _futuresCompleted = 0;
+  }
+
+  Future initialise() {
+    _futuresCompleter = Completer();
+    _initialiseData();
+    // We set busy manually as well because when notify listeners is called to clear error messages the
+    // ui is rebuilt and if you expect busy to be true it's not.
+    setBusy(true);
+    notifyListeners();
+
+    for (var key in futuresMap.keys) {
+      runBusyFuture(futuresMap[key]!(), busyObject: key, throwException: true)
+          .then((futureData) {
+        _dataMap![key] = futureData;
+        setBusyForObject(key, false);
+        notifyListeners();
+        onData(key);
+        _incrementAndCheckFuturesCompleted();
+      }).catchError((error) {
+        setErrorForObject(key, error);
+        setBusyForObject(key, false);
+        onError(key: key, error: error);
+        notifyListeners();
+        _incrementAndCheckFuturesCompleted();
+      });
+    }
+    setBusy(false);
+    changeSource = false;
+
+    return _futuresCompleter.future;
+  }
+
+  void _incrementAndCheckFuturesCompleted() {
+    _futuresCompleted++;
+    if (_futuresCompleted == futuresMap.length &&
+        !_futuresCompleter.isCompleted) {
+      _futuresCompleter.complete();
+    }
+  }
+
+  void onError({String? key, error}) {}
+
+  void onData(String key) {}
+}
+
+/// Provides functionality for a ViewModel to run and fetch data using multiple streams
+abstract class MultipleStreamViewModel extends _MultiDataSourceViewModel
+    implements Initialisable {
+  // Every MultipleStreamViewModel must override streamDataMap
+  // StreamData requires a stream, but lifecycle events are optional
+  // if a lifecyle event isn't defined we use the default ones here
+  Map<String, StreamData> get streamsMap;
+
+  Map<String, StreamSubscription>? _streamsSubscriptions;
+
+  @visibleForTesting
+  Map<String, StreamSubscription>? get streamsSubscriptions =>
+      _streamsSubscriptions;
+
+  /// Returns the stream subscription associated with the key
+  StreamSubscription? getSubscriptionForKey(String key) =>
+      _streamsSubscriptions![key];
+
+  void initialise() {
+    _dataMap = Map<String, dynamic>();
+    clearErrors();
+    _streamsSubscriptions = Map<String, StreamSubscription>();
+
+    if (!changeSource) {
+      notifyListeners();
+    }
+    final _streamsMapValues = Map<String, StreamData>.from(streamsMap);
+
+    for (final key in _streamsMapValues.keys) {
+      // If a lifecycle function isn't supplied, we fallback to default
+      _streamsSubscriptions![key] = _streamsMapValues[key]!.stream.listen(
+        (incomingData) {
+          setErrorForObject(key, null);
+          notifyListeners();
+          // Extra security in case transformData isnt sent
+          var interceptedData = _streamsMapValues[key]!.transformData == null
+              ? transformData(key, incomingData)
+              : _streamsMapValues[key]!.transformData!(incomingData);
+
+          if (interceptedData != null) {
+            _dataMap![key] = interceptedData;
+          } else {
+            _dataMap![key] = incomingData;
+          }
+
+          notifyListeners();
+          _streamsMapValues[key]!.onData != null
+              ? _streamsMapValues[key]!.onData!(_dataMap![key])
+              : onData(key, _dataMap![key]);
+        },
+        onError: (error) {
+          setErrorForObject(key, error);
+          _dataMap![key] = null;
+
+          _streamsMapValues[key]!.onError != null
+              ? _streamsMapValues[key]!.onError!(error)
+              : onError(key, error);
+          notifyListeners();
+        },
+      );
+      _streamsMapValues[key]!.onSubscribed != null
+          ? _streamsMapValues[key]!.onSubscribed!()
+          : onSubscribed(key);
+      changeSource = false;
+    }
+  }
+
+  @override
+  void notifySourceChanged({bool clearOldData = false}) {
+    changeSource = true;
+    _disposeAllSubscriptions();
+
+    if (clearOldData) {
+      dataMap!.clear();
+      clearErrors();
+    }
+
+    notifyListeners();
+  }
+
+  void onData(String key, dynamic data) {}
+  void onSubscribed(String key) {}
+  void onError(String key, error) {}
+  void onCancel(String key) {}
+  dynamic transformData(String key, data) {
+    return data;
+  }
+
+  @override
+  @mustCallSuper
+  void dispose() {
+    _disposeAllSubscriptions();
+    super.dispose();
+  }
+
+  void _disposeAllSubscriptions() {
+    if (_streamsSubscriptions != null) {
+      for (var key in _streamsSubscriptions!.keys) {
+        _streamsSubscriptions![key]!.cancel();
+        onCancel(key);
+      }
+
+      _streamsSubscriptions!.clear();
+    }
+  }
+}

--- a/packages/stacked/lib/src/state_management/single_data_models.dart
+++ b/packages/stacked/lib/src/state_management/single_data_models.dart
@@ -7,6 +7,10 @@ import 'helpers/future_runner_helper.dart';
 import 'helpers/message_state_helper.dart';
 
 /// Provides functionality for a ViewModel that's sole purpose it is to fetch data using a [Future]
+/// This class is mixed with mixins:
+/// - [MessageStateHelper]
+/// - [FutureRunnerHelper]
+/// - [DataStateHelper]
 abstract class FutureViewModel<T> extends DynamicSourceViewModel<T>
     with MessageStateHelper, FutureRunnerHelper, DataStateHelper
     implements Initialisable {
@@ -53,6 +57,10 @@ abstract class FutureViewModel<T> extends DynamicSourceViewModel<T>
   void onData(T? data) {}
 }
 
+/// Provides functionality for a ViewModel that's sole purpose it is to fetch data using a [Stream]
+/// This class is mixed with mixins:
+/// - [MessageStateHelper]
+/// - [DataStateHelper]
 abstract class StreamViewModel<T> extends DynamicSourceViewModel<T>
     with MessageStateHelper, DataStateHelper
     implements Initialisable {

--- a/packages/stacked/lib/src/state_management/single_data_models.dart
+++ b/packages/stacked/lib/src/state_management/single_data_models.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'base_view_models.dart';
+import 'helpers/future_runner_helper.dart';
+import 'helpers/message_state_helper.dart';
+
+/// Provides functionality for a ViewModel that's sole purpose it is to fetch data using a [Future]
+abstract class FutureViewModel<T> extends SingleDataSourceViewModel<T>
+    with MessageStateHelper, FutureRunnerHelper
+    implements Initialisable {
+  // TODO: Add timeout functionality
+  // TODO: Add retry functionality - default 1
+  // TODO: Add retry lifecycle hooks to override in the viewmodel
+
+  /// The future that fetches the data and sets the view to busy
+  Future<T> futureToRun();
+
+  /// Indicates if you want the error caught in futureToRun to be rethrown
+  bool get rethrowException => false;
+
+  Future initialise() async {
+    setError(null);
+    setMessage(null);
+    _error = null;
+    // We set busy manually as well because when notify listeners is called to clear error messages the
+    // ui is rebuilt and if you expect busy to be true it's not.
+    setBusy(true);
+    notifyListeners();
+
+    data = await runBusyFuture<T?>(futureToRun(), throwException: true)
+        .catchError((error) {
+      setError(error);
+      _error = error;
+      setBusy(false);
+      onError(error);
+      notifyListeners();
+      if (rethrowException) {
+        throw error;
+      }
+
+      return null;
+    });
+
+    if (data != null) {
+      onData(data);
+    }
+
+    changeSource = false;
+  }
+
+  /// Called when an error occurs within the future being run
+  void onError(error) {}
+
+  /// Called after the data has been set
+  void onData(T? data) {}
+}
+
+abstract class StreamViewModel<T> extends SingleDataSourceViewModel<T>
+    with MessageStateHelper
+    implements DynamicSourceViewModel<T>, Initialisable {
+  /// Stream to listen to
+  Stream<T> get stream;
+
+  StreamSubscription? get streamSubscription => _streamSubscription;
+
+  StreamSubscription? _streamSubscription;
+
+  @override
+  void notifySourceChanged({bool clearOldData = false}) {
+    changeSource = true;
+    _streamSubscription?.cancel();
+    _streamSubscription = null;
+
+    if (clearOldData) {
+      data = null;
+    }
+
+    notifyListeners();
+  }
+
+  void initialise() {
+    _streamSubscription = stream.listen(
+      (incomingData) {
+        setError(null);
+        setMessage(null);
+        _error = null;
+        notifyListeners();
+        // Extra security in case transformData isnt sent
+        var interceptedData = transformData(incomingData);
+
+        if (interceptedData != null) {
+          data = interceptedData;
+        } else {
+          data = incomingData;
+        }
+
+        onData(data);
+        notifyListeners();
+      },
+      onError: (error) {
+        setError(error);
+        _error = error;
+        data = null;
+        onError(error);
+        notifyListeners();
+      },
+    );
+
+    onSubscribed();
+    changeSource = false;
+  }
+
+  /// Called before the notifyListeners is called when data has been set
+  void onData(T? data) {}
+
+  /// Called when the stream is listened too
+  void onSubscribed() {}
+
+  /// Called when an error is fired in the stream
+  void onError(error) {}
+
+  void onCancel() {}
+
+  /// Called before the data is set for the ViewModel
+  T transformData(T data) {
+    return data;
+  }
+
+  @override
+  void dispose() {
+    _streamSubscription!.cancel();
+    onCancel();
+
+    super.dispose();
+  }
+}

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -6,6 +6,8 @@ export 'src/state_management/form_viewmodel.dart';
 export 'src/state_management/reactive_service_mixin.dart';
 export 'src/state_management/view_model_builder.dart';
 export 'src/state_management/view_model_builder_widget.dart';
+export 'src/state_management/single_data_models.dart';
+export 'src/state_management/multiple_data_models.dart';
 export 'src/state_management/selector_view_model_builder.dart';
 export 'src/state_management/selector_view_model_builder_widget.dart';
 export 'src/state_management/view_model_widget.dart';

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -10,6 +10,10 @@ export 'src/state_management/selector_view_model_builder.dart';
 export 'src/state_management/selector_view_model_builder_widget.dart';
 export 'src/state_management/view_model_widget.dart';
 export 'src/state_management/skeleton_loader.dart';
+export 'src/state_management/helpers/busy_state_helper.dart';
+export 'src/state_management/helpers/error_state_helper.dart';
+export 'src/state_management/helpers/future_runner_helper.dart';
+export 'src/state_management/helpers/message_state_helper.dart';
 
 export 'src/code_generation/router_annotation/extended_navigator.dart';
 export 'src/code_generation/router_annotation/router_base.dart';

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -13,6 +13,10 @@ export 'src/state_management/selector_view_model_builder_widget.dart';
 export 'src/state_management/view_model_widget.dart';
 export 'src/state_management/skeleton_loader.dart';
 
+/// Deprecated viewModels
+export 'src/state_management/form_view_model.dart';
+export 'src/state_management/index_tracking_viewmodel.dart';
+
 /// viewmodel helpers
 export 'src/state_management/helpers/future_runner_helper.dart';
 export 'src/state_management/helpers/message_state_helper.dart';

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -10,8 +10,6 @@ export 'src/state_management/selector_view_model_builder.dart';
 export 'src/state_management/selector_view_model_builder_widget.dart';
 export 'src/state_management/view_model_widget.dart';
 export 'src/state_management/skeleton_loader.dart';
-export 'src/state_management/helpers/busy_state_helper.dart';
-export 'src/state_management/helpers/error_state_helper.dart';
 export 'src/state_management/helpers/future_runner_helper.dart';
 export 'src/state_management/helpers/message_state_helper.dart';
 

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -3,7 +3,7 @@ library stacked;
 /// viewmodels state
 export 'src/state_management/base_view_models.dart';
 export 'src/state_management/index_tracking_viewmodel.dart';
-export 'src/state_management/form_viewmodel.dart';
+export 'src/state_management/helpers/form_state_helper.dart';
 
 export 'src/state_management/reactive_service_mixin.dart';
 export 'src/state_management/view_model_builder.dart';

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -1,8 +1,10 @@
 library stacked;
 
+/// viewmodels state
 export 'src/state_management/base_view_models.dart';
 export 'src/state_management/index_tracking_viewmodel.dart';
 export 'src/state_management/form_viewmodel.dart';
+
 export 'src/state_management/reactive_service_mixin.dart';
 export 'src/state_management/view_model_builder.dart';
 export 'src/state_management/view_model_builder_widget.dart';
@@ -12,8 +14,11 @@ export 'src/state_management/selector_view_model_builder.dart';
 export 'src/state_management/selector_view_model_builder_widget.dart';
 export 'src/state_management/view_model_widget.dart';
 export 'src/state_management/skeleton_loader.dart';
+
+/// viewmodel helpers
 export 'src/state_management/helpers/future_runner_helper.dart';
 export 'src/state_management/helpers/message_state_helper.dart';
+export 'src/state_management/helpers/data_state_helper.dart';
 
 export 'src/code_generation/router_annotation/extended_navigator.dart';
 export 'src/code_generation/router_annotation/router_base.dart';

--- a/packages/stacked/lib/stacked.dart
+++ b/packages/stacked/lib/stacked.dart
@@ -2,8 +2,6 @@ library stacked;
 
 /// viewmodels state
 export 'src/state_management/base_view_models.dart';
-export 'src/state_management/index_tracking_viewmodel.dart';
-export 'src/state_management/helpers/form_state_helper.dart';
 
 export 'src/state_management/reactive_service_mixin.dart';
 export 'src/state_management/view_model_builder.dart';
@@ -19,6 +17,8 @@ export 'src/state_management/skeleton_loader.dart';
 export 'src/state_management/helpers/future_runner_helper.dart';
 export 'src/state_management/helpers/message_state_helper.dart';
 export 'src/state_management/helpers/data_state_helper.dart';
+export 'src/state_management/helpers/index_tracking_state_helper.dart';
+export 'src/state_management/helpers/form_state_helper.dart';
 
 export 'src/code_generation/router_annotation/extended_navigator.dart';
 export 'src/code_generation/router_annotation/router_base.dart';

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -2,7 +2,7 @@ name: stacked
 description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
-version: 2.3.15
+version: 2.4.0
 homepage: https://github.com/FilledStacks/stacked
 
 environment:
@@ -16,7 +16,7 @@ dependencies:
   provider: ^6.0.0
   collection: ^1.15.0
   # Remove the path and use pub one after publish the stacked_core
-  stacked_core: ^1.2.0
+  stacked_core: ^1.2.4
   #universal_io
   universal_io: ^2.0.4
 

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -2,7 +2,7 @@ name: stacked
 description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
-version: 2.4.0
+version: 3.0.0-beta.0
 homepage: https://github.com/FilledStacks/stacked
 
 environment:

--- a/packages/stacked/test/baseviewmodel_test.dart
+++ b/packages/stacked/test/baseviewmodel_test.dart
@@ -1,11 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stacked/src/state_management/helpers/busy_state_helper.dart';
-import 'package:stacked/src/state_management/helpers/error_state_helper.dart';
-import 'package:stacked/src/state_management/helpers/future_runner_helper.dart';
+
 import 'package:stacked/stacked.dart';
 
-class TestViewModel extends BaseViewModel
-    with BusyStateHelper, ErrorStateHelper, FutureRunnerHelper {
+class TestViewModel extends BaseViewModel with FutureRunnerHelper {
   bool onErrorCalled = false;
   Future runFuture(
       {String? busyKey, bool fail = false, bool throwException = false}) {

--- a/packages/stacked/test/baseviewmodel_test.dart
+++ b/packages/stacked/test/baseviewmodel_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stacked/src/state_management/helpers/busy_state_helper.dart';
+import 'package:stacked/src/state_management/helpers/error_state_helper.dart';
+import 'package:stacked/src/state_management/helpers/future_runner_helper.dart';
 import 'package:stacked/stacked.dart';
 
-class TestViewModel extends BaseViewModel {
+class TestViewModel extends BaseViewModel
+    with BusyStateHelper, ErrorStateHelper, FutureRunnerHelper {
   bool onErrorCalled = false;
   Future runFuture(
       {String? busyKey, bool fail = false, bool throwException = false}) {

--- a/packages/stacked/test/form_state_helper_test.dart
+++ b/packages/stacked/test/form_state_helper_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stacked/stacked.dart';
+
+class TestFormViewModel extends BaseViewModel with FormStateHelper {
+  bool setFormStatusCalled = false;
+  @override
+  void setFormStatus() {
+    setFormStatusCalled = true;
+  }
+}
+
+void main() {
+  group('FormStateHelperTest -', () {
+    test('When initialised showValidationMessage Should be false', () {
+      final viewmodel = TestFormViewModel();
+
+      expect(viewmodel.showValidationMessage, isFalse);
+    });
+    test('When initialised validationMessage Should be null', () {
+      final viewmodel = TestFormViewModel();
+
+      expect(viewmodel.validationMessage, isNull);
+    });
+    test('When initialised formValueMap Should be empty', () {
+      final viewmodel = TestFormViewModel();
+
+      expect(viewmodel.formValueMap, isEmpty);
+    });
+    test('When initialised fieldsValidationMessages Should be empty', () {
+      final viewmodel = TestFormViewModel();
+
+      expect(viewmodel.fieldsValidationMessages, isEmpty);
+    });
+
+    group('setValidationMessage -', () {
+      test('When set validation message, validationMessage Should not be null',
+          () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessage('value');
+        expect(viewmodel.validationMessage, isNotNull);
+      });
+      test('When set validation message, validationMessage Should not be null',
+          () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessage('value');
+        expect(viewmodel.validationMessage, isNotNull);
+      });
+    });
+    group('setData -', () {
+      test(
+          'When set new data for a field, Should reset the validation message of that field if exist',
+          () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessages({'name': 'Name is not valid!'});
+        viewmodel.setData({'name': 'newName'});
+
+        expect(viewmodel.fieldsValidationMessages['name'], isNull);
+      });
+      test('When set data, Should call the setFormStatus method', () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setData({'name': 'newName'});
+
+        expect(viewmodel.setFormStatusCalled, isTrue);
+      });
+    });
+    group('setValidationMessages -', () {
+      test(
+          'When called with empty map, Should remove all old validation messages',
+          () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessages({});
+
+        expect(viewmodel.fieldsValidationMessages, isEmpty);
+      });
+      test('When called with a value with null, Should filter it out', () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessages({'name': null});
+
+        expect(viewmodel.fieldsValidationMessages, isEmpty);
+      });
+      test('When called with a non-nullable value, Should add it', () {
+        final viewmodel = TestFormViewModel();
+        viewmodel.setValidationMessages({'name': 'tName'});
+
+        expect(viewmodel.fieldsValidationMessages['name'], 'tName');
+      });
+    });
+  });
+}

--- a/packages/stacked/test/futureviewmodel_test.dart
+++ b/packages/stacked/test/futureviewmodel_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stacked/stacked.dart';
+import 'package:stacked/src/state_management/multiple_data_models.dart';
+import 'package:stacked/src/state_management/single_data_models.dart';
 
 const _SingleFutureExceptionFailMessage = 'Future to Run failed';
 

--- a/packages/stacked/test/index_tracking_viewmodel_test.dart
+++ b/packages/stacked/test/index_tracking_viewmodel_test.dart
@@ -1,17 +1,20 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stacked/src/state_management/index_tracking_viewmodel.dart';
+import 'package:stacked/stacked.dart';
+
+class TestIndexTrackingViewModel extends BaseViewModel
+    with IndexTrackingStateHelper {}
 
 void main() {
   group('IndexTrackingViewmodelTest -', () {
     group('setIndex -', () {
       test('When called with 1, should set currentIndex to 1', () {
-        var viewModel = IndexTrackingViewModel();
+        var viewModel = TestIndexTrackingViewModel();
         viewModel.setIndex(1);
         expect(viewModel.currentIndex, 1);
       });
 
       test('When called with 1, should notifyListeners about update', () {
-        var viewModel = IndexTrackingViewModel();
+        var viewModel = TestIndexTrackingViewModel();
         var called = false;
         viewModel.addListener(() {
           called = true;
@@ -23,7 +26,7 @@ void main() {
       test(
           'When called with 1 and currentIndex was 0, reverse should return false',
           () {
-        var viewModel = IndexTrackingViewModel();
+        var viewModel = TestIndexTrackingViewModel();
         viewModel.setIndex(1);
         expect(viewModel.reverse, false);
       });
@@ -31,7 +34,7 @@ void main() {
       test(
           'When called with 0 and currentIndex was 1, reverse should return true',
           () {
-        var viewModel = IndexTrackingViewModel();
+        var viewModel = TestIndexTrackingViewModel();
         viewModel.setIndex(1);
 
         viewModel.setIndex(0);
@@ -39,13 +42,13 @@ void main() {
       });
 
       test('When called with 1 isIndexSelected should return false for 0', () {
-        var model = IndexTrackingViewModel();
+        var model = TestIndexTrackingViewModel();
         model.setIndex(1);
         expect(model.isIndexSelected(0), false);
       });
 
       test('When called with 1 isIndexSelected should return true for 1', () {
-        var viewModel = IndexTrackingViewModel();
+        var viewModel = TestIndexTrackingViewModel();
         viewModel.setIndex(1);
         expect(viewModel.isIndexSelected(1), true);
       });

--- a/packages/stacked/test/reactive_viewmodel_test.dart
+++ b/packages/stacked/test/reactive_viewmodel_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stacked/src/state_management/base_view_models.dart';
 import 'package:stacked/src/state_management/reactive_service_mixin.dart';
+import 'package:stacked/src/state_management/single_data_models.dart';
 
 class TestReactiveService with ReactiveServiceMixin {
   int _counter = 0;

--- a/packages/stacked/test/streamviewmodel_test.dart
+++ b/packages/stacked/test/streamviewmodel_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stacked/src/state_management/multiple_data_models.dart';
+import 'package:stacked/src/state_management/single_data_models.dart';
 import 'package:stacked/stacked.dart';
 
 Stream<int> numberStream(int dataBack,

--- a/packages/stacked/test/streamviewmodel_test.dart
+++ b/packages/stacked/test/streamviewmodel_test.dart
@@ -1,6 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stacked/src/state_management/multiple_data_models.dart';
-import 'package:stacked/src/state_management/single_data_models.dart';
 import 'package:stacked/stacked.dart';
 
 Stream<int> numberStream(int dataBack,

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,4 +1,6 @@
 
+## 0.7.16-beta.0
+- Replace `FormViewModel` to `FormStateHelper`
 ## 0.7.15
 
 - Updates analyzer package

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -208,7 +208,7 @@ class FormBuilder with StringBufferUtils {
     writeLine('''
               /// Registers a listener on every generated controller that calls [model.setData()]
               /// with the latest textController values
-              void listenToFormUpdated(FormViewModel model) {
+              void listenToFormUpdated(FormStateHelper model) {
             ''');
 
     for (final field in fields.onlyTextFieldConfigs) {
@@ -225,7 +225,7 @@ class FormBuilder with StringBufferUtils {
     writeLine(
         "final bool _autoTextFieldValidation = $autoTextFieldValidation;");
     writeLine("""
-    bool validateFormFields(FormViewModel model) {
+    bool validateFormFields(FormStateHelper model) {
       _updateFormData(model, forceValidate: true);
       return model.isFormValid;
     }
@@ -236,8 +236,8 @@ class FormBuilder with StringBufferUtils {
   FormBuilder addFormDataUpdateFunctionTorTextControllers() {
     if (fields.onlyTextFieldConfigs.isEmpty) return this;
     writeLine('''
-        /// Updates the formData on the FormViewModel
-        void _updateFormData(FormViewModel model, {bool forceValidate = false}) { model.setData(
+        /// Updates the formData on the FormStateHelper
+        void _updateFormData(FormStateHelper model, {bool forceValidate = false}) { model.setData(
               model.formValueMap
                 ..addAll({
             ''');
@@ -260,8 +260,8 @@ class FormBuilder with StringBufferUtils {
   FormBuilder addValidationDataUpdateFunctionTorTextControllers() {
     if (fields.onlyTextFieldConfigs.isEmpty) return this;
     writeLine('''
-        /// Updates the fieldsValidationMessages on the FormViewModel
-        void _updateValidationData(FormViewModel model) => model.setValidationMessages(
+        /// Updates the fieldsValidationMessages on the FormStateHelper
+        void _updateValidationData(FormStateHelper model) => model.setValidationMessages(
               {
             ''');
 
@@ -318,7 +318,7 @@ class FormBuilder with StringBufferUtils {
 
   FormBuilder addFormViewModelExtensionForGetters() {
     newLine();
-    writeLine('extension ValueProperties on FormViewModel {');
+    writeLine('extension ValueProperties on FormStateHelper {');
     writeLine("""bool get isFormValid =>
       this.fieldsValidationMessages.values.every((element) => element == null);""");
     for (final field in fields) {
@@ -358,7 +358,7 @@ class FormBuilder with StringBufferUtils {
 
   FormBuilder addFormViewModelExtensionForMethods() {
     newLine();
-    writeLine('extension Methods on FormViewModel {');
+    writeLine('extension Methods on FormStateHelper {');
 
     // Generate the date pickers
     for (final field in fields.onlyDateFieldConfigs) {

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.7.15
+version: 0.7.16-beta.0
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/form/constant_test_helper.dart
+++ b/packages/stacked_generator/test/form/constant_test_helper.dart
@@ -64,8 +64,8 @@ final Map<String, FocusNode> _TestViewFocusNodes = {};
 
 ''';
 const kExample1UpdateFormData = '''
-        /// Updates the formData on the FormViewModel
-        void _updateFormData(FormViewModel model, {bool forceValidate = false}) { model.setData(
+        /// Updates the formData on the FormStateHelper
+        void _updateFormData(FormStateHelper model, {bool forceValidate = false}) { model.setData(
               model.formValueMap
                 ..addAll({
             
@@ -79,7 +79,7 @@ EmailValueKey: emailController.text,
 ''';
 const kExample1ViewModelExtensionForGetters = '''
 
-extension ValueProperties on FormViewModel {
+extension ValueProperties on FormStateHelper {
 bool get isFormValid =>
       this.fieldsValidationMessages.values.every((element) => element == null);
 String? get nameValue => this.formValueMap[NameValueKey] as String?;
@@ -105,7 +105,7 @@ String? get dropDownValidationMessage => this.fieldsValidationMessages[DropDownV
 ''';
 const kExample1ViewModelExtensionForMethods = '''
 
-extension Methods on FormViewModel {
+extension Methods on FormStateHelper {
           Future<void> selectDate(
               {required BuildContext context,
               required DateTime initialDate,
@@ -197,7 +197,7 @@ import 'validators/path';
 const kExample1AddListenerRegistrationsForTextFields =
     '''              /// Registers a listener on every generated controller that calls [model.setData()]
               /// with the latest textController values
-              void listenToFormUpdated(FormViewModel model) {
+              void listenToFormUpdated(FormStateHelper model) {
             
 nameController.addListener(() => _updateFormData(model));
 emailController.addListener(() => _updateFormData(model));
@@ -205,8 +205,8 @@ emailController.addListener(() => _updateFormData(model));
 
 ''';
 const kExample1AddValidationDataUpdateFunctionTorTextControllers = '''
-        /// Updates the fieldsValidationMessages on the FormViewModel
-        void _updateValidationData(FormViewModel model) => model.setValidationMessages(
+        /// Updates the fieldsValidationMessages on the FormStateHelper
+        void _updateValidationData(FormStateHelper model) => model.setValidationMessages(
               {
             
 NameValueKey: _getValidationMessage(NameValueKey),


### PR DESCRIPTION
- Refactor `BaseViewModel` by extracting the different functionalities to mixins.
- Remove the inconsistency between the `BaseViewModel` and `FutureViewModel`, `StreamViewModel` when setting the error, data values.
- Now we have three mixins that can be mix with any viewmodel and they are:
  - `FutureRunnerHelper` that has `runBusyFuture` and `runErrorFuture` functions
  - `MessageStateHelper` that adds message proberty to the viewmodel
  - `DataStateHelper` that adds data proberty to the viewmodel
  - `FormStateHelper` that give the flexibility to use the `formviewmodel` with `futureviewmodel` for example
  - `IndexTrackingStateHelper` that give the flexibility to use the `IndexTrackingStateHelper` with `futureviewmodel` for example

Note: this change needs one small change in the form generator which is replace `FormViewModel` with `FormStateHelper`