### PR TITLE
fixed stacked-cli not generating locator and router file

### DIFF
--- a/packages/stacked_tools/lib/src/templates/app/pubspec.yaml.stk
+++ b/packages/stacked_tools/lib/src/templates/app/pubspec.yaml.stk
@@ -50,7 +50,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   build_runner: ^2.2.0
 
-  stacked_generator: ^0.7.13
+  stacked_generator: ^0.7.15
   mockito: ^5.1.0
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
Running 'stacked create app <app_name>' in terminal using the CLI tool . Locator and Router file was not generated for the app folder in the new app. This is because the stacked_generator version in the stacked_tool package is old. This fix added the latest version of the stacked_generator.