### PR TITLE
Feat/close snackbar

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.5
+- Adds `closeSnackbar` method to be able to close the snackbar programmatically
+- Removes nullability on the `isSnackbarOpen` getter
 ## 0.9.4
 - Adds `id` to the `popUntil` function in `NavigationService` to allow for nested navigation
 ## 0.9.3

--- a/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
@@ -220,6 +220,13 @@ class SnackbarService {
     }
   }
 
+  /// Close the current snack bar
+  Future<void> closeSnackbar() async{
+    if(isSnackbarOpen){
+      return Get.closeCurrentSnackbar();
+    }
+  }
+
   TextButton? _getMainButtonWidget({
     String? mainButtonTitle,
     ButtonStyle? mainButtonStyle,

--- a/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
+++ b/packages/stacked_services/lib/src/snackbar/snackbar_service.dart
@@ -48,7 +48,7 @@ class SnackbarService {
   }
 
   /// Check if snackbar is open
-  bool? get isSnackbarOpen => Get.isSnackbarOpen;
+  bool get isSnackbarOpen => Get.isSnackbarOpen;
 
   /// Shows a snack bar with the details passed in
   void showSnackbar({

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.9.4
+version: 0.9.5
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:


### PR DESCRIPTION
There can be scenarios where you want to programatically close the current snackbar.
* The message is no longer relevant, e.g.: you show 'no connection warning' and in the meanwhile the device reconnected