### PR TITLE
[stacked_generator] Fix/deprecated element

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## 0.7.15
+
+- Updates analyzer package
+- Fixes deprecated element and enclosingElement2
 ## 0.7.14
 
 - Add `instanceName` parameter to the DependencyRegistration annotation

--- a/packages/stacked_generator/lib/import_resolver.dart
+++ b/packages/stacked_generator/lib/import_resolver.dart
@@ -36,7 +36,7 @@ class ImportResolver {
 
   Set<String> resolveAll(DartType type) {
     final imports = <String>{};
-    final resolvedValue = resolve(type.element);
+    final resolvedValue = resolve(type.element2);
     if (resolvedValue != null) {
       imports.add(resolvedValue);
     }
@@ -48,7 +48,7 @@ class ImportResolver {
     final imports = <String>{};
     if (typeToCheck is ParameterizedType) {
       for (DartType type in typeToCheck.typeArguments) {
-        final resolvedValue = resolve(type.element);
+        final resolvedValue = resolve(type.element2);
         if (resolvedValue != null) {
           imports.add(resolvedValue);
         }

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
@@ -20,7 +20,7 @@ class BottomsheetConfigResolver {
       final bottomsheetClassType =
           bottomsheetReader.read('classType').typeValue;
 
-      final classElement = bottomsheetClassType.element as ClassElement?;
+      final classElement = bottomsheetClassType.element2 as ClassElement?;
 
       // Get the import of the class type that's defined for the bottomSheet
       final import = importResolver.resolve(classElement!);

--- a/packages/stacked_generator/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
@@ -20,7 +20,7 @@ class DialogConfigResolver {
       // Get the type of the dialog that we want to register
       final dialogClassType = dialogReader.read('classType').typeValue;
 
-      final classElement = dialogClassType.element as ClassElement?;
+      final classElement = dialogClassType.element2 as ClassElement?;
 
       // Get the import of the class type that's defined for the dialog
       final import = importResolver.resolve(classElement!);

--- a/packages/stacked_generator/lib/src/generators/forms/field_config.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/field_config.dart
@@ -88,5 +88,5 @@ extension ExecutableElementDataExtension on ExecutableElement? {
       ? '${enclosingElementName}.${this?.name}'
       : this?.name;
   bool get hasEnclosingElementName => enclosingElementName != null;
-  String? get enclosingElementName => this?.enclosingElement2.name;
+  String? get enclosingElementName => this?.enclosingElement3.name;
 }

--- a/packages/stacked_generator/lib/src/generators/getit/dependency_config_factory.dart
+++ b/packages/stacked_generator/lib/src/generators/getit/dependency_config_factory.dart
@@ -35,7 +35,7 @@ class DependencyConfigFactory {
       '🛑 No dependency class Type defined for ${dependencyConfig.toString()}. Please make sure that any of the services provided to the services list in the StackedApp annotation has a service provided. Please see the documentation for stacked_generator if you don\'t know what this means.',
     );
 
-    final classElement = dependencyClassType!.element as ClassElement?;
+    final classElement = dependencyClassType!.element2 as ClassElement?;
 
     throwIf(
       classElement == null,
@@ -54,7 +54,7 @@ class DependencyConfigFactory {
     final import = importResolver.resolve(classElement!);
 
     final abstractedClassElement =
-        dependencyAbstractedClassType?.element as ClassElement?;
+        dependencyAbstractedClassType?.element2 as ClassElement?;
 
     final abstractedImport = importResolver.resolve(abstractedClassElement);
 

--- a/packages/stacked_generator/lib/src/generators/logging/logger_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_config_resolver.dart
@@ -60,6 +60,6 @@ class LoggerConfigResolver {
 
   ClassElement _dartOjectToElemet(DartObject obj) {
     var dependencyReader = ConstantReader(obj).typeValue;
-    return dependencyReader.element as ClassElement;
+    return dependencyReader.element2 as ClassElement;
   }
 }

--- a/packages/stacked_generator/lib/src/generators/router/route_config/route_config_factory.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_config/route_config_factory.dart
@@ -75,11 +75,11 @@ class RouteConfigFactory {
       if (function != null) {
         final displayName = function.displayName.replaceFirst(RegExp('^_'), '');
         final functionName = function.isStatic
-            ? '${function.enclosingElement2.displayName}.$displayName'
+            ? '${function.enclosingElement3.displayName}.$displayName'
             : displayName;
 
         String? import;
-        if (function.enclosingElement2.name != 'TransitionsBuilders') {
+        if (function.enclosingElement3.name != 'TransitionsBuilders') {
           import = function.source.uri.toString();
         }
         customTransitionBuilder = CustomTransitionBuilder(functionName, import);

--- a/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/router/route_config_resolver.dart
@@ -24,12 +24,12 @@ class RouteConfigResolver {
       {String? parentClassName}) async {
     final dartType = stackedRoute.read('page').typeValue;
     throwIf(
-      dartType.element is! ClassElement,
+      dartType.element2 is! ClassElement,
       '${toDisplayString(dartType)} is not a class element',
-      element: dartType.element!,
+      element: dartType.element2!,
     );
 
-    final classElement = dartType.element as ClassElement;
+    final classElement = dartType.element2 as ClassElement;
     final import = _importResolver.resolve(classElement);
     final classNameWithImport = MapEntry(toDisplayString(dartType), import!);
 

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   logger: ^1.1.0
   stacked_core: ^1.2.4
   # Removing this will cause issues when publish the package
-  analyzer: ^4.3.0
+  analyzer: ^4.6.0
   dart_style: ^2.2.3
   code_builder: ^4.2.0
   collection: ^1.16.0

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.7.14
+version: 0.7.15
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
I updated the analyze package and replace the deprecated element and enclosingElement2, because `flutter analyze` on stacked_generator has some issues:
```
flutter analyze
Running "flutter pub get" in stacked_generator...                   3.1s
Analyzing stacked_generator...

   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/import_resolver.dart:39:40 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/import_resolver.dart:51:44 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart:23:49 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/dialogs/resolve/dialog_config_resolver.dart:23:44 • deprecated_member_use
   info • 'enclosingElement2' is deprecated and shouldn't be used. Use enclosingElement3 instead • lib/src/generators/forms/field_config.dart:91:45 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/getit/dependency_config_factory.dart:38:47 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/getit/dependency_config_factory.dart:57:40 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/logging/logger_config_resolver.dart:63:29 • deprecated_member_use
   info • 'enclosingElement2' is deprecated and shouldn't be used. Use enclosingElement3 instead • lib/src/generators/router/route_config/route_config_factory.dart:78:27 •
          deprecated_member_use
   info • 'enclosingElement2' is deprecated and shouldn't be used. Use enclosingElement3 instead • lib/src/generators/router/route_config/route_config_factory.dart:82:22 •
          deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/router/route_config_resolver.dart:27:16 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/router/route_config_resolver.dart:29:25 • deprecated_member_use
   info • 'element' is deprecated and shouldn't be used. Use element2 instead • lib/src/generators/router/route_config_resolver.dart:32:35 • deprecated_member_use

13 issues found. (ran in 4.6s)
```