### PR TITLE
add supported platforms explicitly

### DIFF
--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -23,3 +23,12 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# pub.dev was not able to automatically detects the supporting platforms, so here are listed explicitly
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:


### PR DESCRIPTION
See the issue #724 

In the [docs](https://dart.dev/tools/pub/pubspec#platforms) they say to add the supported platforms explicitly in pubspec.yaml , but never done this before, so please correct me if I'm wrong.

I believe the `stacked` package is supporting all the platforms, there's no native code or dependency. Personally tested iOS, Android, web, macOs