### PR TITLE
Suggestion: setting the state with 'setState'

### DIFF
--- a/packages/stacked/lib/src/state_management/base_view_models.dart
+++ b/packages/stacked/lib/src/state_management/base_view_models.dart
@@ -23,6 +23,16 @@ class BaseViewModel extends ChangeNotifier
     disposed = true;
     super.dispose();
   }
+
+  void setState(void Function()? fn) {
+    fn?.call();
+    notifyListeners();
+  }
+
+  Future<void> setStateAsync(Future<void> Function()? fn) async {
+    await fn?.call();
+    notifyListeners();
+  }
 }
 
 /// A [BaseViewModel] that provides functionality to subscribe to a reactive service.


### PR DESCRIPTION
Hey, I've always had my own extensions on BaseViewModel, and I'm putting one of them here as a suggestion to integrate into the package. Nothing crucial but maybe also other people can benefit from that.

Suggestion:
I never liked the fact that I always need to call the `notifyListeners()` after setting the state in ViewModel. The suggestion is to use a `setState()` callback. It encapsulates the whole concept of notifying UI, and does exactly what it should - **Setting the State**. It's subjective, but for me, the readability is much better.

```dart
class AnyViewModel extends BaseViewModel {
  int _postCount = 0;
  int get postCount => _postCount;

  // Old Approach
  void setPostCount(int count) {
    _postCount = count;
    notifyListeners();
  }

  // New Approach
  void setPostCount(int count) {
    setState(() {
      _postCount = count;
    });
  }
}

```