### PR TITLE
SignInWithApple: Made asking for full name configurable

### DIFF
--- a/packages/stacked_firebase_auth/CHANGELOG.md
+++ b/packages/stacked_firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.18
+
+- Improves signInWithApple. Made asking for full name configurable
+
 ## 0.2.17
 
 - Bumps firebase packages to latest

--- a/packages/stacked_firebase_auth/pubspec.yaml
+++ b/packages/stacked_firebase_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
-version: 0.2.17
+version: 0.2.18
 homepage: https://github.com/FilledStacks/stacked
 
 environment:


### PR DESCRIPTION
Apple will reject your app if you ask for the name when you sign in, but do not use it in the app.