### PR TITLE
Add listeners count getter

### DIFF
--- a/packages/stacked/lib/src/state_management/reactive_service_mixin.dart
+++ b/packages/stacked/lib/src/state_management/reactive_service_mixin.dart
@@ -6,6 +6,9 @@ import '../../stacked.dart';
 mixin ReactiveServiceMixin {
   List<Function> _listeners = List<Function>.empty(growable: true);
 
+  /// Make available listeners count to extending classes
+  int get listenersCount => _listeners.length;
+
   /// List to the values and react when there are any changes
   void listenToReactiveValues(List<dynamic> reactiveValues) {
     for (var reactiveValue in reactiveValues) {


### PR DESCRIPTION
Sometimes it is useful when reactive service has knowledge about its listeners. You can then make decisions base on that. For example I would like to cancel some listener but if there are listeners I won't do cancellation.