### PR TITLE
Fix/missing prefix of enum default value in router generator

### DIFF
--- a/packages/stacked/example/lib/app/app.router.dart
+++ b/packages/stacked/example/lib/app/app.router.dart
@@ -6,9 +6,10 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:example/app/custom_route_transition.dart' as _i7;
-import 'package:example/datamodels/clashable_one.dart' as _i10;
+import 'package:example/datamodels/clashable_one.dart' as _i9;
 import 'package:example/datamodels/clashable_two.dart' as _i11;
-import 'package:example/datamodels/home_type.dart' as _i8;
+import 'package:example/datamodels/home_type.dart' as _i10;
+import 'package:example/datamodels/home_type.dart';
 import 'package:example/ui/bottom_nav/bottom_nav_example.dart' as _i3;
 import 'package:example/ui/bottom_nav/favorites/favorites_view.dart' as _i12;
 import 'package:example/ui/bottom_nav/history/history_view.dart' as _i13;
@@ -20,7 +21,7 @@ import 'package:example/ui/multiple_futures_example/multiple_futures_example_vie
 import 'package:example/ui/nonreactive/nonreactive_view.dart' as _i6;
 import 'package:example/ui/stream_view/stream_counter_view.dart' as _i4;
 import 'package:flutter/cupertino.dart' as _i16;
-import 'package:flutter/material.dart' as _i9;
+import 'package:flutter/material.dart' as _i8;
 import 'package:flutter/material.dart';
 import 'package:stacked/src/code_generation/router_annotation/transitions_builders.dart'
     as _i15;
@@ -67,7 +68,8 @@ class StackedRouter extends _i1.RouterBase {
             title: args.title,
             isLoggedIn: args.isLoggedIn,
             clashableGetter: args.clashableGetter,
-            homeType: args.homeType),
+            homeType: args.homeType,
+            homeTypes: args.homeTypes),
         settings: data,
       );
     },
@@ -116,23 +118,26 @@ class HomeViewArguments {
       this.title = 'hello',
       this.isLoggedIn = false,
       this.clashableGetter,
-      this.homeType = _i8.HomeType.apartment});
+      this.homeType = HomeType.apartment,
+      this.homeTypes = const [HomeType.apartment, HomeType.house]});
 
-  final _i9.Key? key;
+  final _i8.Key? key;
 
   final String? title;
 
   final bool? isLoggedIn;
 
-  final _i10.Clashable Function(String)? clashableGetter;
+  final _i9.Clashable Function(String)? clashableGetter;
 
-  final _i8.HomeType homeType;
+  final _i10.HomeType homeType;
+
+  final List<_i10.HomeType> homeTypes;
 }
 
 class StreamCounterViewArguments {
   const StreamCounterViewArguments({this.key, required this.clashableTwo});
 
-  final _i9.Key? key;
+  final _i8.Key? key;
 
   final List<_i11.Clashable> clashableTwo;
 }
@@ -140,9 +145,9 @@ class StreamCounterViewArguments {
 class ExampleFormViewArguments {
   const ExampleFormViewArguments({this.key, required this.clashableOne});
 
-  final _i9.Key? key;
+  final _i8.Key? key;
 
-  final _i10.Clashable clashableOne;
+  final _i9.Clashable clashableOne;
 }
 
 class BottomNavExampleRoutes {
@@ -198,7 +203,7 @@ class BottomNavExampleRouter extends _i1.RouterBase {
 class NestedFavoritesViewArguments {
   const NestedFavoritesViewArguments({this.key, this.id});
 
-  final _i9.Key? key;
+  final _i8.Key? key;
 
   final String? id;
 }
@@ -245,12 +250,16 @@ class FavoritesViewRouter extends _i1.RouterBase {
 }
 
 extension NavigatorStateExtension on _i18.NavigationService {
-  Future<dynamic> navigateToHomeView(
-      {_i9.Key? key,
+  Future<dynamic> navigateTohomeView(
+      {_i8.Key? key,
       String? title = 'hello',
       bool? isLoggedIn = false,
-      _i10.Clashable Function(String)? clashableGetter,
-      _i8.HomeType homeType = _i8.HomeType.apartment,
+      _i9.Clashable Function(String)? clashableGetter,
+      _i10.HomeType homeType = HomeType.apartment,
+      List<_i10.HomeType> homeTypes = const [
+        HomeType.apartment,
+        HomeType.house
+      ],
       int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -263,14 +272,15 @@ extension NavigatorStateExtension on _i18.NavigationService {
             title: title,
             isLoggedIn: isLoggedIn,
             clashableGetter: clashableGetter,
-            homeType: homeType),
+            homeType: homeType,
+            homeTypes: homeTypes),
         id: routerId,
         preventDuplicates: preventDuplicates,
         parameters: parameters,
         transition: transition);
   }
 
-  Future<dynamic> navigateToBottomNavExample(
+  Future<dynamic> navigateTobottomNavExample(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -284,8 +294,8 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToStreamCounterView(
-      {_i9.Key? key,
+  Future<dynamic> navigateTostreamCounterView(
+      {_i8.Key? key,
       required List<_i11.Clashable> clashableTwo,
       int? routerId,
       bool preventDuplicates = true,
@@ -302,9 +312,9 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToExampleFormView(
-      {_i9.Key? key,
-      required _i10.Clashable clashableOne,
+  Future<dynamic> navigateToexampleFormView(
+      {_i8.Key? key,
+      required _i9.Clashable clashableOne,
       int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -320,7 +330,7 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNonReactiveView(
+  Future<dynamic> navigateTononReactiveView(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -334,8 +344,8 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNestedFavoritesViewInBottomNavExample(
-      {_i9.Key? key,
+  Future<dynamic> navigateToNestedfavoritesViewInBottomNavExample(
+      {_i8.Key? key,
       String? id,
       int? routerId,
       bool preventDuplicates = true,
@@ -351,7 +361,7 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNestedHistoryViewInBottomNavExample(
+  Future<dynamic> navigateToNestedhistoryViewInBottomNavExample(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -365,7 +375,7 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNestedProfileViewInBottomNavExample(
+  Future<dynamic> navigateToNestedprofileViewInBottomNavExample(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -379,7 +389,7 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNestedMultipleFuturesExampleViewInFavoritesView(
+  Future<dynamic> navigateToNestedmultipleFuturesExampleViewInFavoritesView(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,
@@ -393,7 +403,7 @@ extension NavigatorStateExtension on _i18.NavigationService {
         transition: transition);
   }
 
-  Future<dynamic> navigateToNestedHistoryViewInFavoritesView(
+  Future<dynamic> navigateToNestedhistoryViewInFavoritesView(
       [int? routerId,
       bool preventDuplicates = true,
       Map<String, String>? parameters,

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -91,8 +91,8 @@ mixin $ExampleFormView on StatelessWidget {
     return model.isFormValid;
   }
 
-  /// Updates the formData on the dynamic
-  void _updateFormData(dynamic model, {bool forceValidate = false}) {
+  /// Updates the formData on the FormViewModel
+  void _updateFormData(FormViewModel model, {bool forceValidate = false}) {
     model.setData(
       model.formValueMap
         ..addAll({
@@ -106,8 +106,9 @@ mixin $ExampleFormView on StatelessWidget {
     }
   }
 
-  /// Updates the fieldsValidationMessages on the dynamic
-  void _updateValidationData(dynamic model) => model.setValidationMessages({
+  /// Updates the fieldsValidationMessages on the FormViewModel
+  void _updateValidationData(FormViewModel model) =>
+      model.setValidationMessages({
         EmailValueKey: _getValidationMessage(EmailValueKey),
         PasswordValueKey: _getValidationMessage(PasswordValueKey),
         ShortBioValueKey: _getValidationMessage(ShortBioValueKey),

--- a/packages/stacked/example/lib/ui/home/home_view.dart
+++ b/packages/stacked/example/lib/ui/home/home_view.dart
@@ -11,6 +11,7 @@ class HomeView extends StatelessWidget {
   final String? title;
   final bool? isLoggedIn;
   final HomeType homeType;
+  final List<HomeType> homeTypes;
   final Clashable Function(String name)? clashableGetter;
 
   const HomeView({
@@ -19,6 +20,10 @@ class HomeView extends StatelessWidget {
     this.isLoggedIn = false,
     this.clashableGetter,
     this.homeType = HomeType.apartment,
+    this.homeTypes = const [
+      HomeType.apartment,
+      HomeType.house,
+    ],
   }) : super(key: key);
 
   @override

--- a/packages/stacked/example/lib/ui/home/home_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/home/home_viewmodel.dart
@@ -13,7 +13,7 @@ class HomeViewModel extends BaseViewModel with MessageStateHelper {
   int counter = 0;
 
   void navigate() {
-    _navigationService.navigateToNonReactiveView();
+    _navigationService.navigateTononReactiveView();
   }
 
   void initialise() {

--- a/packages/stacked/example/lib/ui/nonreactive/nonreactive_viewmodel.dart
+++ b/packages/stacked/example/lib/ui/nonreactive/nonreactive_viewmodel.dart
@@ -16,7 +16,7 @@ class NonReactiveViewModel extends BaseViewModel {
 
   void navigateToNewView() {
     _navigationService
-        .navigateToStreamCounterView(clashableTwo: [const Clashable(22)]);
+        .navigateTostreamCounterView(clashableTwo: [const Clashable(22)]);
   }
 
   void navigateBackHome() {

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.8.1-beta.2
 
+- Fixes [#745](https://github.com/FilledStacks/stacked/issues/745)
+
+## 0.8.1-beta.2
+
 - Fixes [#740](https://github.com/FilledStacks/stacked/issues/740)
 
 ## 0.8.1-beta.1

--- a/packages/stacked_generator/lib/resolved_type.dart
+++ b/packages/stacked_generator/lib/resolved_type.dart
@@ -25,7 +25,7 @@ class ResolvedType {
 
   @override
   String toString() {
-    return name;
+    return 'name : $name, import : $import, typeArguments: ${typeArguments.map((element) => element.toString())}';
   }
 
   @override

--- a/packages/stacked_generator/lib/src/generators/extensions/string_utils_extension.dart
+++ b/packages/stacked_generator/lib/src/generators/extensions/string_utils_extension.dart
@@ -7,20 +7,14 @@ extension NullableStringUtilsExtension on String? {
     return ", instanceName: '$this'";
   }
 
-  /// Inorder to replace this             with             this
-  ///                     ||                                ||
-  ///                     \/                                \/
-  /// String? !=null ? String? + String : null        String? + String
-  ///
-  ///
-  ///
-  String? operator +(String rightSide) {
-    final leftSide = this;
+  /// Overload the + operator to handle nullable and non-nullable addtion
+  String? operator +(String right) {
+    final left = this;
 
-    if (leftSide == null) {
-      return leftSide;
+    if (left == null) {
+      return left;
     } else {
-      return leftSide + rightSide;
+      return left + right;
     }
   }
 }

--- a/packages/stacked_generator/lib/src/generators/extensions/string_utils_extension.dart
+++ b/packages/stacked_generator/lib/src/generators/extensions/string_utils_extension.dart
@@ -6,6 +6,23 @@ extension NullableStringUtilsExtension on String? {
 
     return ", instanceName: '$this'";
   }
+
+  /// Inorder to replace this             with             this
+  ///                     ||                                ||
+  ///                     \/                                \/
+  /// String? !=null ? String? + String : null        String? + String
+  ///
+  ///
+  ///
+  String? operator +(String rightSide) {
+    final leftSide = this;
+
+    if (leftSide == null) {
+      return leftSide;
+    } else {
+      return leftSide + rightSide;
+    }
+  }
 }
 
 extension StringUtilsExtension on String {

--- a/packages/stacked_generator/lib/src/generators/router/generator/arguments_class/argument_class_builder_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/router/generator/arguments_class/argument_class_builder_helper.dart
@@ -1,6 +1,9 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:stacked_generator/route_config_resolver.dart';
 
+import '../route_allocator.dart';
+import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+
 class ArgumentClassBuilderHelper {
   final RouteConfig route;
 
@@ -40,8 +43,10 @@ class ArgumentClassBuilderHelper {
 
         // Assign default value
         if (param.defaultValueCode != null) {
-          parameterBuilder.defaultTo =
-              refer(param.defaultValueCode!, param.type.import).code;
+          parameterBuilder.defaultTo = refer(
+            param.defaultValueCode!,
+            param.type.import + kFlagToPreventAliasingTheImport,
+          ).code;
         }
 
         // Add required keyword

--- a/packages/stacked_generator/lib/src/generators/router/generator/navigate_extension_class/navigate_extension_class_builder_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/router/generator/navigate_extension_class/navigate_extension_class_builder_helper.dart
@@ -2,6 +2,9 @@ import 'package:code_builder/code_builder.dart';
 import 'package:stacked_generator/route_config_resolver.dart';
 import 'package:stacked_generator/utils.dart';
 
+import '../route_allocator.dart';
+import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+
 class NavigateExtensionClassBuilderHelper {
   Iterable<Method> buildNavigateToExtensionMethods(List<RouteConfig> routes) {
     return routes.map<Method>(extractNavigationMethodFromRoute);
@@ -39,8 +42,10 @@ class NavigateExtensionClassBuilderHelper {
 
       // Assign default value
       if (param.defaultValueCode != null) {
-        parameterBuilder.defaultTo =
-            refer(param.defaultValueCode!, param.type.import).code;
+        parameterBuilder.defaultTo = refer(
+          param.defaultValueCode!,
+          param.type.import + kFlagToPreventAliasingTheImport,
+        ).code;
       }
 
       // Add required keyword

--- a/packages/stacked_generator/lib/src/generators/router/generator/route_allocator.dart
+++ b/packages/stacked_generator/lib/src/generators/router/generator/route_allocator.dart
@@ -1,0 +1,37 @@
+import 'package:code_builder/code_builder.dart';
+
+/// Add This Word To The End Of Any Import To UnAlias It
+const kFlagToPreventAliasingTheImport = '#EXCLUDE';
+
+class RouteAllocator implements Allocator {
+  final _doNotPrefix = ['dart:core'];
+
+  final _doNotPrefixImports = <String>{};
+  final _imports = <String, int>{};
+  var _keys = 1;
+
+  @override
+  String allocate(Reference reference) {
+    final symbol = reference.symbol;
+    final url = reference.url;
+    if (url == null || _doNotPrefix.contains(url)) {
+      return symbol!;
+    }
+    if (reference.url!.endsWith(kFlagToPreventAliasingTheImport)) {
+      _doNotPrefixImports
+          .add(reference.url!.replaceAll(kFlagToPreventAliasingTheImport, ''));
+      return symbol!;
+    }
+
+    return '_i${_imports.putIfAbsent(url, _nextKey)}.$symbol';
+  }
+
+  int _nextKey() => _keys++;
+
+  @override
+  Iterable<Directive> get imports => _imports.keys
+      .map(
+        (u) => Directive.import(u, as: '_i${_imports[u]}'),
+      )
+      .followedBy(_doNotPrefixImports.map((e) => Directive.import(e)));
+}

--- a/packages/stacked_generator/lib/src/generators/router/generator/router_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/router/generator/router_generator.dart
@@ -7,6 +7,7 @@ import 'package:stacked_generator/src/generators/router/generator/routes_class/r
 import '../router_config/router_config.dart';
 import 'arguments_class/arguments_class_builder.dart';
 import 'navigate_extension_class/navigate_extension_class_builder.dart';
+import 'route_allocator.dart';
 import 'router_class/router_class_builder.dart';
 
 class RouterGenerator implements BaseGenerator {
@@ -16,7 +17,7 @@ class RouterGenerator implements BaseGenerator {
 
   /// Where we store the result of [_generateClasses]
   List<Spec> classes = [];
-
+  List<String> notAliasedImports = [];
   @override
   String generate() {
     if (_rootRouterConfig.routes.isEmpty) return '';
@@ -39,8 +40,11 @@ class RouterGenerator implements BaseGenerator {
         ..body.addAll([...classes, navigationExtensionClassBuilder]),
     );
 
-    final emitter =
-        DartEmitter.scoped(orderDirectives: true, useNullSafetySyntax: true);
+    final emitter = DartEmitter(
+      allocator: RouteAllocator(),
+      useNullSafetySyntax: true,
+      orderDirectives: true,
+    );
 
     return DartFormatter().format('${library.accept(emitter)}');
   }

--- a/packages/stacked_generator/lib/src/generators/router/models/route_parameter_config.dart
+++ b/packages/stacked_generator/lib/src/generators/router/models/route_parameter_config.dart
@@ -45,6 +45,11 @@ class RouteParamConfig {
   }
 
   String? get paramName => alias ?? name;
+
+  @override
+  String toString() {
+    return 'defaultValueCode : $defaultValueCode, name : $name, type : $type';
+  }
 }
 
 class RouteParameterResolver {

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.1-beta.2
+version: 0.8.1-beta.3
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
Fixes #745 

- Exclude the default values imports from being aliased by adding a custom Allocator that Exempt all the import that ends with #EXCLUDE word