### PR TITLE
Fix typed navigation on nested views

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0+2
+
+- Fix [#767](https://github.com/FilledStacks/stacked/issues/767)
+
 ## 3.0.0+1
 
 - Replace the old `ReactiveValues` approach with `notifyListeners()` when using the `ReactiveServiceMixin` in readme

--- a/packages/stacked/pubspec.yaml
+++ b/packages/stacked/pubspec.yaml
@@ -2,7 +2,7 @@ name: stacked
 description: An architecture and widgets for an MVVM inspired architecture in
   Flutter. It provides common functionalities required to build a large
   application in a understandable manner.
-version: 3.0.0+1
+version: 3.0.0+2
 homepage: https://github.com/FilledStacks/stacked
 
 funding:

--- a/packages/stacked_generator/lib/src/generators/router/router_config/router_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/router/router_config/router_config_resolver.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/route_config_resolver.dart';
+import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
 import 'package:stacked_generator/type_resolver.dart';
 
 import 'router_config.dart';
@@ -51,8 +52,14 @@ class RouterConfigResolver {
       final children = routeReader.peek('children')?.listValue;
 
       if (children?.isNotEmpty ?? false) {
-        final childrenRoutes = await _resolveRoutes(routerConfig, children!,
-            parentClassName: route.className.key);
+        final childrenRoutes = await _resolveRoutes(
+          routerConfig,
+          children!,
+          parentClassName:
+              route.className.key.toLowerCase() != route.name.toLowerCase()
+                  ? route.name.capitalize
+                  : route.className.key,
+        );
         route = route.copyWith(children: childrenRoutes);
       }
       allRoutes.add(route);


### PR DESCRIPTION
When route.className.key is different of route.name, we should use name because has higher priority, otherwise, we use route.className.key.

Fixes #767 