### PR TITLE
Adds better form value checking for text fields value checks

### DIFF
--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -150,9 +150,15 @@ extension ValueProperties on FormViewModel {
   String? get doYouLoveFoodValue =>
       this.formValueMap[DoYouLoveFoodValueKey] as String?;
 
-  bool get hasEmail => this.formValueMap.containsKey(EmailValueKey);
-  bool get hasPassword => this.formValueMap.containsKey(PasswordValueKey);
-  bool get hasShortBio => this.formValueMap.containsKey(ShortBioValueKey);
+  bool get hasEmail =>
+      this.formValueMap.containsKey(EmailValueKey) &&
+      (emailValue?.isNotEmpty ?? false);
+  bool get hasPassword =>
+      this.formValueMap.containsKey(PasswordValueKey) &&
+      (passwordValue?.isNotEmpty ?? false);
+  bool get hasShortBio =>
+      this.formValueMap.containsKey(ShortBioValueKey) &&
+      (shortBioValue?.isNotEmpty ?? false);
   bool get hasBirthDate => this.formValueMap.containsKey(BirthDateValueKey);
   bool get hasDoYouLoveFood =>
       this.formValueMap.containsKey(DoYouLoveFoodValueKey);

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+* Fixes #[#773](https://github.com/FilledStacks/stacked/issues/773) by adding better `has[FormField]` checking.
+
 ## 0.8.1-beta.5
 
 - Fix [#766](https://github.com/FilledStacks/stacked/issues/766)

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -332,8 +332,13 @@ class FormBuilder with StringBufferUtils {
     newLine();
     for (final field in fields) {
       final caseName = ReCase(field.name);
+      final requiresAdditionalCheck = field is TextFieldConfig;
+      final additionalCheck = requiresAdditionalCheck
+          ? ' && (${caseName.camelCase}Value?.isNotEmpty ?? false)'
+          : '';
       writeLine(
-          'bool get has${caseName.pascalCase} => this.formValueMap.containsKey(${_getFormKeyName(caseName)});');
+        'bool get has${caseName.pascalCase} => this.formValueMap.containsKey(${_getFormKeyName(caseName)})$additionalCheck;',
+      );
     }
 
     // Generate the getters that check whether a field has validation message or not

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.1-beta.5
+version: 0.8.1
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/form/constant_test_helper.dart
+++ b/packages/stacked_generator/test/form/constant_test_helper.dart
@@ -87,8 +87,8 @@ String? get emailValue => this.formValueMap[EmailValueKey] as String?;
 DateTime? get dateValue => this.formValueMap[DateValueKey] as DateTime?;
 String? get dropDownValue => this.formValueMap[DropDownValueKey] as String?;
 
-bool get hasName => this.formValueMap.containsKey(NameValueKey);
-bool get hasEmail => this.formValueMap.containsKey(EmailValueKey);
+bool get hasName => this.formValueMap.containsKey(NameValueKey) && (nameValue?.isNotEmpty ?? false);
+bool get hasEmail => this.formValueMap.containsKey(EmailValueKey) && (emailValue?.isNotEmpty ?? false);
 bool get hasDate => this.formValueMap.containsKey(DateValueKey);
 bool get hasDropDown => this.formValueMap.containsKey(DropDownValueKey);
 


### PR DESCRIPTION
The hasValue check for text fields has an additional check to see if the value is empty. This removes the false positives for hasValue in cases where the text field is cleared and the key is still present