### PR TITLE
Removes extra space on log output

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2
+
+* Removes extra space on log output
+
 ## 0.8.1
 
 * Fixes #[#773](https://github.com/FilledStacks/stacked/issues/773) by adding better `has[FormField]` checking.

--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -37,7 +37,7 @@ class SimpleLogPrinter extends LogPrinter {
     var methodName = _getMethodName();
 
     var methodNameSection =
-        printCallingFunctionName && methodName != null ? ' | \$methodName ' : '';
+        printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
         '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
+++ b/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
@@ -35,7 +35,7 @@ class SimpleLogPrinter extends LogPrinter {
     var methodName = _getMethodName();
 
     var methodNameSection =
-        printCallingFunctionName && methodName != null ? ' | \$methodName ' : '';
+        printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
         '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
@@ -213,7 +213,7 @@ class SimpleLogPrinter extends LogPrinter {
     var methodName = _getMethodName();
 
     var methodNameSection =
-        printCallingFunctionName && methodName != null ? ' | \$methodName ' : '';
+        printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
         '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';


### PR DESCRIPTION
Removes extra space on log output just after method name.