### PR TITLE
add listen param to getParentViewModel function

### DIFF
--- a/packages/stacked/lib/src/state_management/view_model_builder.dart
+++ b/packages/stacked/lib/src/state_management/view_model_builder.dart
@@ -181,4 +181,5 @@ class _ViewModelBuilderState<T extends ChangeNotifier>
 }
 
 /// EXPERIMENTAL: Returns the ViewModel provided above this widget in the tree
-T getParentViewModel<T>(BuildContext context) => Provider.of<T>(context);
+T getParentViewModel<T>(BuildContext context, {bool listen = true}) =>
+    Provider.of<T>(context, listen: listen);


### PR DESCRIPTION
Added listen param so we can tell Provider to not rebuild or rebuild the widget.