### PR TITLE
Deprecate listenToFormUpdated

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.3-beta.0
+
+* Replaces `syncFormWithViewModel` with deprecated `listenToFormUpdated`
+
 ## 0.8.2
 
 * Removes extra space on log output

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -206,14 +206,33 @@ class FormBuilder with StringBufferUtils {
 
   FormBuilder addListenerRegistrationsForTextFields() {
     writeLine('''
-              /// Registers a listener on every generated controller that calls [model.setData()]
-              /// with the latest textController values
-              void listenToFormUpdated(FormViewModel model) {
-            ''');
+      /// Registers a listener on every generated controller that calls [model.setData()]
+      /// with the latest textController values
+      void syncFormWithViewModel(FormViewModel model) {
+    ''');
 
     for (final field in fields.onlyTextFieldConfigs) {
       writeLine(
-          '${_getControllerName(field)}.addListener(() => _updateFormData(model));');
+        '${_getControllerName(field)}.addListener(() => _updateFormData(model));',
+      );
+    }
+    writeLine('}');
+    newLine();
+
+    writeLine('''
+      /// Registers a listener on every generated controller that calls [model.setData()]
+      /// with the latest textController values
+      @Deprecated(
+        'Use syncFormWithViewModel instead.'
+        'This feature was deprecated after 3.1.0.'
+      )
+      void listenToFormUpdated(FormViewModel model) {
+    ''');
+
+    for (final field in fields.onlyTextFieldConfigs) {
+      writeLine(
+        '${_getControllerName(field)}.addListener(() => _updateFormData(model));',
+      );
     }
     writeLine('}');
     newLine();

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.2
+version: 0.8.3-beta.0
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/form/constant_test_helper.dart
+++ b/packages/stacked_generator/test/form/constant_test_helper.dart
@@ -194,10 +194,10 @@ import 'validators/path';
 
 
 ''';
-const kExample1AddListenerRegistrationsForTextFields =
-    '''              /// Registers a listener on every generated controller that calls [model.setData()]
-              /// with the latest textController values
-              void listenToFormUpdated(FormViewModel model) {
+const kExample1AddListenerRegistrationsForTextFields = '''
+  /// Registers a listener on every generated controller that calls [model.setData()]
+  /// with the latest textController values
+  void syncFormWithViewModel(FormViewModel model) {
             
 nameController.addListener(() => _updateFormData(model));
 emailController.addListener(() => _updateFormData(model));

--- a/packages/stacked_generator/test/form/constant_test_helper.dart
+++ b/packages/stacked_generator/test/form/constant_test_helper.dart
@@ -195,10 +195,22 @@ import 'validators/path';
 
 ''';
 const kExample1AddListenerRegistrationsForTextFields = '''
-  /// Registers a listener on every generated controller that calls [model.setData()]
-  /// with the latest textController values
-  void syncFormWithViewModel(FormViewModel model) {
-            
+      /// Registers a listener on every generated controller that calls [model.setData()]
+      /// with the latest textController values
+      void syncFormWithViewModel(FormViewModel model) {
+    
+nameController.addListener(() => _updateFormData(model));
+emailController.addListener(() => _updateFormData(model));
+}
+
+      /// Registers a listener on every generated controller that calls [model.setData()]
+      /// with the latest textController values
+      @Deprecated(
+        'Use syncFormWithViewModel instead.'
+        'This feature was deprecated after 3.1.0.'
+      )
+      void listenToFormUpdated(FormViewModel model) {
+    
 nameController.addListener(() => _updateFormData(model));
 emailController.addListener(() => _updateFormData(model));
 }


### PR DESCRIPTION
Replaced `syncFormWithViewModel` with deprecated `listenToFormUpdated`.