### PR TITLE
Replace double quotes with simple quotes

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4
+
+* Replaces double quotes with simple quotes on `_splitClassNameWords` at `SimpleLogPrinter`.
+
 ## 0.8.3
 
 * Adds new `replaceWith[ViewName]` extension method

--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -86,7 +86,7 @@ class SimpleLogPrinter extends LogPrinter {
 
   List<String> _splitClassNameWords(String className) {
   return className
-      .split(RegExp(r"(?=[A-Z])"))
+      .split(RegExp(r'(?=[A-Z])'))
       .map((e) => e.toLowerCase())
       .toList();
   }

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.3
+version: 0.8.4
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/getit/integration_test/samples/factory/factory.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/factory/factory.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithoneparam.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithoneparam.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithtwoparam.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithtwoparam.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithtype.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/factory/factorywithtype.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/singleton/lazysingleton.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/singleton/lazysingleton.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/singleton/presolvedsingleton.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/singleton/presolvedsingleton.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/singleton/singleton.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/singleton/singleton.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/singleton/singletonwithresolve.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/singleton/singletonwithresolve.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/getit/integration_test/samples/singleton/singletonwithtype.locator.dart
+++ b/packages/stacked_generator/test/getit/integration_test/samples/singleton/singletonwithtype.locator.dart
@@ -4,7 +4,7 @@
 // StackedLocatorGenerator
 // **************************************************************************
 
-// ignore_for_file: public_member_api_docs
+// ignore_for_file: public_member_api_docs, implementation_imports, depend_on_referenced_packages
 
 import 'package:stacked_core/stacked_core.dart';
 

--- a/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
+++ b/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
@@ -84,7 +84,7 @@ class SimpleLogPrinter extends LogPrinter {
 
   List<String> _splitClassNameWords(String className) {
   return className
-      .split(RegExp(r"(?=[A-Z])"))
+      .split(RegExp(r'(?=[A-Z])'))
       .map((e) => e.toLowerCase())
       .toList();
   }
@@ -262,7 +262,7 @@ class SimpleLogPrinter extends LogPrinter {
 
   List<String> _splitClassNameWords(String className) {
   return className
-      .split(RegExp(r"(?=[A-Z])"))
+      .split(RegExp(r'(?=[A-Z])'))
       .map((e) => e.toLowerCase())
       .toList();
   }

--- a/packages/stacked_generator/test/logging/web_support_test.dart
+++ b/packages/stacked_generator/test/logging/web_support_test.dart
@@ -2,7 +2,7 @@ import 'package:test/test.dart';
 
 List<String> _splitClassNameWords(String className) {
   return className
-      .split(RegExp(r"(?=[A-Z])"))
+      .split(RegExp(r'(?=[A-Z])'))
       .map((e) => e.toLowerCase())
       .toList();
 }


### PR DESCRIPTION
This change was made only for consistency on quotes used. A user on Slack, `Niraj Nandish`, was having issues with their linting.