### PR TITLE
Replace stacked_tools strings with stacked_cli

### DIFF
--- a/packages/stacked_cli/CHANGELOG.md
+++ b/packages/stacked_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3+1
+
+- Replaces `stacked_tools` strings with `stacked_cli`
+
 ## 1.1.3
 
 - Updates the `HomeViewModel` template to use `rebuildUi` instead of `notifyListeners`

--- a/packages/stacked_cli/bin/stacked.dart
+++ b/packages/stacked_cli/bin/stacked.dart
@@ -14,7 +14,7 @@ Future<void> main(List<String> arguments) async {
 
   try {
     CommandRunner(
-      'stacked_tools',
+      'stacked_cli',
       'A command line interface for building and scaffolding stacked apps',
     )
       ..addCommand(CreateCommand())

--- a/packages/stacked_cli/lib/src/constants/message_constants.dart
+++ b/packages/stacked_cli/lib/src/constants/message_constants.dart
@@ -10,7 +10,7 @@ const String kInvalidStackedStructureAppFile =
 /// running from.
 const String kInvalidRootDirectory = '''
     No pubspec.yaml detected. It seems that you are not running the cli from the root of a flutter project. 
-    Please ensure that you are in the root of a flutter project when using stacked_tools.
+    Please ensure that you are in the root of a flutter project when using stacked_cli.
     ''';
 
 /// The message shown when we detect that the stacked structure does not follow the latest

--- a/packages/stacked_cli/pubspec.yaml
+++ b/packages/stacked_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.1.3
+version: 1.1.3+1
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/packages/stacked_cli/test/helpers/test_helpers.dart
+++ b/packages/stacked_cli/test/helpers/test_helpers.dart
@@ -67,7 +67,7 @@ MockProcessService getAndRegisterProcessService() {
 }
 
 MockPubspecService getAndRegisterPubSpecService({
-  String packageName = 'stacked_tools',
+  String packageName = 'stacked_cli',
 }) {
   _removeRegistrationIfExists<PubspecService>();
   final service = MockPubspecService();


### PR DESCRIPTION
There was some references to `stacked_tools` on the help output.