### PR TITLE
Update DialogBuilder and SheetBuilder typedefs

### DIFF
--- a/packages/stacked_services/CHANGELOG.md
+++ b/packages/stacked_services/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.9+1
+
+- Updates DialogBuider and SheetBuilder typedefs
+
 ## 0.9.9
 - Adds all properties to the show snackbar cofig
 

--- a/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
+++ b/packages/stacked_services/lib/src/bottom_sheet/bottom_sheet_service.dart
@@ -10,7 +10,10 @@ import 'package:stacked_services/src/models/overlay_response.dart';
 import 'bottom_sheet_ui.dart';
 
 typedef SheetBuilder = Widget Function(
-    BuildContext, SheetRequest, void Function(SheetResponse));
+  BuildContext context,
+  SheetRequest<dynamic> request,
+  void Function(SheetResponse<dynamic> response) completer,
+);
 
 /// A service that allows you to show a bottom sheet
 class BottomSheetService {

--- a/packages/stacked_services/lib/src/dialog/dialog_service.dart
+++ b/packages/stacked_services/lib/src/dialog/dialog_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:stacked_services/src/dialog/platform_dialog.dart';
@@ -8,7 +7,10 @@ import 'package:stacked_services/src/models/overlay_request.dart';
 import 'package:stacked_services/src/models/overlay_response.dart';
 
 typedef DialogBuilder = Widget Function(
-    BuildContext, DialogRequest, void Function(DialogResponse));
+  BuildContext context,
+  DialogRequest<dynamic> request,
+  void Function(DialogResponse<dynamic> response) completer,
+);
 
 enum DialogPlatform {
   Cupertino,

--- a/packages/stacked_services/pubspec.yaml
+++ b/packages/stacked_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_services
 description: A package that contains some default implementations of services required for a cleaner implementation of the Stacked Architecture.
-version: 0.9.9
+version: 0.9.9+1
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_services
 
 environment:


### PR DESCRIPTION
Updated DialogBuilder and SheetBuilder typedefs. I didn't see they were there when I created the BottomSheetBuilder typedef, I will use this one on the cli I'm preparing that PR also.