### PR TITLE
Fix version global option

### DIFF
--- a/packages/stacked_cli/CHANGELOG.md
+++ b/packages/stacked_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.9
+
+- Fixes version global option
+
 ## 1.1.8
 
 - Adds global option to show `stacked_cli` version

--- a/packages/stacked_cli/bin/stacked.dart
+++ b/packages/stacked_cli/bin/stacked.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:pubspec_yaml/pubspec_yaml.dart';
 import 'package:stacked_cli/src/commands/compile/compile_command.dart';
 import 'package:stacked_cli/src/commands/create/create_command.dart';
 import 'package:stacked_cli/src/commands/delete/delete_command.dart';
@@ -12,6 +11,7 @@ import 'package:stacked_cli/src/constants/command_constants.dart';
 import 'package:stacked_cli/src/constants/message_constants.dart';
 import 'package:stacked_cli/src/exceptions/invalid_stacked_structure_exception.dart';
 import 'package:stacked_cli/src/locator.dart';
+import 'package:stacked_cli/src/models/version.g.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
 
 Future<void> main(List<String> arguments) async {
@@ -72,15 +72,16 @@ Future<void> main(List<String> arguments) async {
   }
 }
 
+/// Prints version of the application.
 bool _handleVersion(ArgResults argResults) {
   if (!argResults[ksVersion]) return false;
 
-  final pubspec = File('pubspec.yaml').readAsStringSync().toPubspecYaml();
-  stdout.writeln(pubspec.version.valueOr(() => ''));
+  stdout.writeln(version);
 
   return true;
 }
 
+/// Enables or disables sending of analytics data.
 bool _handleAnalytics(ArgResults argResults) {
   if (argResults[ksEnableAnalytics]) {
     locator<AnalyticsService>().enable(true);
@@ -95,6 +96,7 @@ bool _handleAnalytics(ArgResults argResults) {
   return false;
 }
 
+/// Allows user decide to enable or not analytics on first run.
 Future<void> _handleFirstRun() async {
   final analyticsService = locator<AnalyticsService>();
   if (!analyticsService.isFirstRun) return;

--- a/packages/stacked_cli/lib/src/commands/generate/generate_command.dart
+++ b/packages/stacked_cli/lib/src/commands/generate/generate_command.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:path/path.dart';
+import 'package:pubspec_yaml/pubspec_yaml.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
 import 'package:stacked_cli/src/services/process_service.dart';
@@ -19,6 +22,24 @@ class GenerateCommand extends Command {
   @override
   Future<void> run() async {
     unawaited(_analyticsService.generateCodeEvent());
+    await _generateVersion();
     await _processService.runBuildRunner();
+  }
+
+  Future<void> _generateVersion() async {
+    final pubspec = File('pubspec.yaml').readAsStringSync().toPubspecYaml();
+    final version = pubspec.version.valueOr(() => '');
+
+    final outputPath = joinAll([
+      Directory.current.path,
+      'lib',
+      'src',
+      'models',
+      'version.g.dart',
+    ]);
+
+    final fileContent =
+        "// GENERATED CODE - DO NOT MODIFY BY HAND\nconst String version = '$version';\n";
+    await File(outputPath).writeAsString(fileContent);
   }
 }

--- a/packages/stacked_cli/lib/src/models/config_model.freezed.dart
+++ b/packages/stacked_cli/lib/src/models/config_model.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
 part of 'config_model.dart';
 

--- a/packages/stacked_cli/lib/src/models/template_models.freezed.dart
+++ b/packages/stacked_cli/lib/src/models/template_models.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
 
 part of 'template_models.dart';
 
@@ -366,7 +366,6 @@ class _$_CompiledStackedTemplate implements _CompiledStackedTemplate {
   final List<CompliledTemplateFile> _templateFiles;
   @override
   List<CompliledTemplateFile> get templateFiles {
-    if (_templateFiles is EqualUnmodifiableListView) return _templateFiles;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_templateFiles);
   }
@@ -375,8 +374,6 @@ class _$_CompiledStackedTemplate implements _CompiledStackedTemplate {
   @override
   @JsonKey()
   List<CompiledFileModification> get modificationFiles {
-    if (_modificationFiles is EqualUnmodifiableListView)
-      return _modificationFiles;
     // ignore: implicit_dynamic_type
     return EqualUnmodifiableListView(_modificationFiles);
   }

--- a/packages/stacked_cli/lib/src/models/version.g.dart
+++ b/packages/stacked_cli/lib/src/models/version.g.dart
@@ -1,0 +1,2 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+const String version = '1.1.8';

--- a/packages/stacked_cli/lib/src/models/version.g.dart
+++ b/packages/stacked_cli/lib/src/models/version.g.dart
@@ -1,2 +1,2 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-const String version = '1.1.8';
+const String version = '1.1.9';

--- a/packages/stacked_cli/pubspec.yaml
+++ b/packages/stacked_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.1.8
+version: 1.1.9
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/packages/stacked_cli/test/helpers/test_helpers.mocks.dart
+++ b/packages/stacked_cli/test/helpers/test_helpers.mocks.dart
@@ -1066,6 +1066,26 @@ class MockProcessService extends _i1.Mock implements _i15.ProcessService {
 /// See the documentation for Mockito's code generation for more information.
 class MockAnalyticsService extends _i1.Mock implements _i16.AnalyticsService {
   @override
+  bool get isFirstRun => (super.noSuchMethod(
+        Invocation.getter(#isFirstRun),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  bool get enabled => (super.noSuchMethod(
+        Invocation.getter(#enabled),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+  @override
+  void enable(bool? value) => super.noSuchMethod(
+        Invocation.method(
+          #enable,
+          [value],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   _i6.Future<void> createAppEvent({required String? name}) =>
       (super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
@FilledStacks I don't know if this can be added to `stacked_generator` to avoid running generate command on every version bump. For now, fixes the issue. I don't know if it is worth it to improve it.