### PR TITLE
Refactor ProcessService and version global option

### DIFF
--- a/packages/stacked_cli/CHANGELOG.md
+++ b/packages/stacked_cli/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.9+1
+
+- Refactor ProcessService
+- Improves version global option to be retrieved on the fly
+
 ## 1.1.9
 
 - Fixes version global option

--- a/packages/stacked_cli/bin/stacked.dart
+++ b/packages/stacked_cli/bin/stacked.dart
@@ -11,8 +11,8 @@ import 'package:stacked_cli/src/constants/command_constants.dart';
 import 'package:stacked_cli/src/constants/message_constants.dart';
 import 'package:stacked_cli/src/exceptions/invalid_stacked_structure_exception.dart';
 import 'package:stacked_cli/src/locator.dart';
-import 'package:stacked_cli/src/models/version.g.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
+import 'package:stacked_cli/src/services/process_service.dart';
 
 Future<void> main(List<String> arguments) async {
   await setupLocator();
@@ -47,7 +47,7 @@ Future<void> main(List<String> arguments) async {
     final argResults = runner.parse(arguments);
     await _handleFirstRun();
 
-    if (_handleVersion(argResults)) exit(0);
+    if (await _handleVersion(argResults)) exit(0);
 
     if (_handleAnalytics(argResults)) exit(0);
 
@@ -73,10 +73,17 @@ Future<void> main(List<String> arguments) async {
 }
 
 /// Prints version of the application.
-bool _handleVersion(ArgResults argResults) {
+Future<bool> _handleVersion(ArgResults argResults) async {
   if (!argResults[ksVersion]) return false;
 
-  stdout.writeln(version);
+  final packages = await locator<ProcessService>().runPubGlobalList();
+  for (var package in packages) {
+    if (!package.contains('stacked_cli')) continue;
+
+    final version = package.split(' ').last;
+    stdout.writeln(version);
+    break;
+  }
 
   return true;
 }

--- a/packages/stacked_cli/lib/src/commands/create/create_app_command.dart
+++ b/packages/stacked_cli/lib/src/commands/create/create_app_command.dart
@@ -79,30 +79,19 @@ class CreateAppCommand extends Command {
       verbose: false,
     );
 
-    // Analyze the project and write the output into a log file
-    await _processService.runAnalyzeAndWriteLogFile(appName: appName);
-
-    final issues = await _fileService.readFileAsLines(
-      filePath: '$appName/$ksLogFile',
-    );
+    // Analyze the project and return output lines
+    final issues = await _processService.runAnalyze(appName: appName);
 
     for (var i in issues) {
-      if (!i.startsWith('[info] Unused import')) continue;
+      if (!i.endsWith('unused_import')) continue;
 
-      final log =
-          i.split(' ').last.replaceAll('(', '').replaceAll(')', '').split(':');
+      final log = i.split(' • ')[2].split(':');
 
       await _fileService.removeLinesOnFile(
-        filePath: log[0],
+        filePath: '$appName/${log[0]}',
         linesNumber: [int.parse(log[1])],
       );
     }
-
-    // Delete log file to clean the project
-    await _fileService.deleteFile(
-      filePath: '$appName/$ksLogFile',
-      verbose: false,
-    );
 
     _cLog.stackedOutput(message: 'Project cleaned.');
   }

--- a/packages/stacked_cli/lib/src/commands/generate/generate_command.dart
+++ b/packages/stacked_cli/lib/src/commands/generate/generate_command.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:path/path.dart';
-import 'package:pubspec_yaml/pubspec_yaml.dart';
 import 'package:stacked_cli/src/locator.dart';
 import 'package:stacked_cli/src/services/analytics_service.dart';
 import 'package:stacked_cli/src/services/process_service.dart';
 
 class GenerateCommand extends Command {
-  final _processService = locator<ProcessService>();
   final _analyticsService = locator<AnalyticsService>();
+  final _processService = locator<ProcessService>();
 
   @override
   String get description =>
@@ -22,24 +19,6 @@ class GenerateCommand extends Command {
   @override
   Future<void> run() async {
     unawaited(_analyticsService.generateCodeEvent());
-    await _generateVersion();
     await _processService.runBuildRunner();
-  }
-
-  Future<void> _generateVersion() async {
-    final pubspec = File('pubspec.yaml').readAsStringSync().toPubspecYaml();
-    final version = pubspec.version.valueOr(() => '');
-
-    final outputPath = joinAll([
-      Directory.current.path,
-      'lib',
-      'src',
-      'models',
-      'version.g.dart',
-    ]);
-
-    final fileContent =
-        "// GENERATED CODE - DO NOT MODIFY BY HAND\nconst String version = '$version';\n";
-    await File(outputPath).writeAsString(fileContent);
   }
 }

--- a/packages/stacked_cli/lib/src/commands/update/update_command.dart
+++ b/packages/stacked_cli/lib/src/commands/update/update_command.dart
@@ -18,6 +18,6 @@ class UpdateCommand extends Command {
   @override
   Future<void> run() async {
     unawaited(_analyticsService.updateCliEvent());
-    await _processService.runPubGlobal();
+    await _processService.runPubGlobalActivate();
   }
 }

--- a/packages/stacked_cli/lib/src/constants/command_constants.dart
+++ b/packages/stacked_cli/lib/src/constants/command_constants.dart
@@ -20,11 +20,10 @@ const String ksLineLength = 'line-length';
 const String ksExcludeDependency = 'exclude-dependency';
 const String ksCurrentDirectory = '.';
 const String ksGlobal = 'global';
+const String ksList = 'list';
 const String ksActivate = 'activate';
 const String ksStackedCli = 'stacked_cli';
 const String ksAnalyze = 'analyze';
-const String ksWrite = '--write';
-const String ksLogFile = '.stacked.analyze.log';
 
 /// A list of strings that are used to run the pub run build runner build --delete-conflicting-outputs command.
 const List<String> buildRunnerArguments = [
@@ -38,8 +37,15 @@ const List<String> buildRunnerArguments = [
 /// A list of strings that are used to run the pub get command.
 const List<String> pubGetArguments = [ksPub, ksGet];
 
-/// A list of strings that are used to run the pub global command.
-const List<String> pubGlobalArguments = [
+/// A list of strings that are used to run the pub global list command.
+const List<String> pubGlobalListArguments = [
+  ksPub,
+  ksGlobal,
+  ksList,
+];
+
+/// A list of strings that are used to run the pub global activate command.
+const List<String> pubGlobalActivateArguments = [
   ksPub,
   ksGlobal,
   ksActivate,
@@ -47,4 +53,4 @@ const List<String> pubGlobalArguments = [
 ];
 
 /// A list of strings that are used to run the analyze command.
-const List<String> analyzeArguments = [ksAnalyze, ksWrite, ksLogFile];
+const List<String> analyzeArguments = [ksAnalyze];

--- a/packages/stacked_cli/lib/src/models/version.g.dart
+++ b/packages/stacked_cli/lib/src/models/version.g.dart
@@ -1,2 +1,0 @@
-// GENERATED CODE - DO NOT MODIFY BY HAND
-const String version = '1.1.9';

--- a/packages/stacked_cli/pubspec.yaml
+++ b/packages/stacked_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.1.9
+version: 1.1.9+1
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/packages/stacked_cli/test/helpers/test_helpers.mocks.dart
+++ b/packages/stacked_cli/test/helpers/test_helpers.mocks.dart
@@ -1032,25 +1032,33 @@ class MockProcessService extends _i1.Mock implements _i15.ProcessService {
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
-  _i6.Future<void> runPubGlobal() => (super.noSuchMethod(
+  _i6.Future<void> runPubGlobalActivate() => (super.noSuchMethod(
         Invocation.method(
-          #runPubGlobal,
+          #runPubGlobalActivate,
           [],
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
   @override
-  _i6.Future<void> runAnalyzeAndWriteLogFile({String? appName}) =>
-      (super.noSuchMethod(
+  _i6.Future<List<String>> runPubGlobalList() => (super.noSuchMethod(
         Invocation.method(
-          #runAnalyzeAndWriteLogFile,
+          #runPubGlobalList,
+          [],
+        ),
+        returnValue: _i6.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
+      ) as _i6.Future<List<String>>);
+  @override
+  _i6.Future<List<String>> runAnalyze({String? appName}) => (super.noSuchMethod(
+        Invocation.method(
+          #runAnalyze,
           [],
           {#appName: appName},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i6.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i6.Future<List<String>>.value(<String>[]),
+      ) as _i6.Future<List<String>>);
   @override
   void logSuccessStatus(int? exitCode) => super.noSuchMethod(
         Invocation.method(


### PR DESCRIPTION
- Added `_runProcess` private function which replaces `_runProcessAndLogOut` and `_runProcessInSilence` functions
- Added `runPubGlobalList` to retrieve a list of dart packages installed
- Refactored `runAnalyze` function to avoid using a temporal file
- Refactored `_handleVersion` to get version on the fly