### PR TITLE
[generator] Align BottomSheets and Dialogs generators with Stacked

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.5
+
+- Changes builder name from dialog to dialogs
+- Removes `Sheet` word at end of enum value on BottomSheets
+- Removes `Dialog` word at end of enum value on Dialogs
+- Adds Stacked template identifiers
+- Changes Map type for builders, more precised
+
 ## 0.8.4
 
 * Replaces double quotes with simple quotes on `_splitClassNameWords` at `SimpleLogPrinter`.

--- a/packages/stacked_generator/build.yaml
+++ b/packages/stacked_generator/build.yaml
@@ -68,7 +68,7 @@ builders:
   stackedDialogGenerator:
     import: "package:stacked_generator/builder.dart"
     builder_factories: ["stackedDialogGenerator"]
-    build_extensions: { ".dart": [".dialog.dart"] }
+    build_extensions: { ".dart": [".dialogs.dart"] }
     auto_apply: dependents
     build_to: source
 

--- a/packages/stacked_generator/lib/builder.dart
+++ b/packages/stacked_generator/lib/builder.dart
@@ -39,7 +39,7 @@ Builder stackedLoggerGenerator(BuilderOptions options) {
 Builder stackedDialogGenerator(BuilderOptions options) {
   return LibraryBuilder(
     StackedDialogGenerator(),
-    generatedExtension: '.dialog.dart',
+    generatedExtension: '.dialogs.dart',
   );
 }
 

--- a/packages/stacked_generator/lib/import_resolver.dart
+++ b/packages/stacked_generator/lib/import_resolver.dart
@@ -15,9 +15,10 @@ class ImportResolver {
     }
 
     for (var lib in libs) {
-      if (!_isCoreDartType(lib) &&
-          lib.exportNamespace.definedNames.keys.contains(element?.name)) {
-        var package = lib.source.uri.pathSegments.first;
+      if (_isCoreDartType(lib)) continue;
+
+      if (lib.exportNamespace.definedNames.keys.contains(element?.name)) {
+        final package = lib.source.uri.pathSegments.first;
         if (targetFilePath.startsWith(RegExp('^$package/'))) {
           return p.posix
               .relative(element?.source?.uri.path ?? '', from: targetFilePath)
@@ -27,6 +28,7 @@ class ImportResolver {
         }
       }
     }
+
     return null;
   }
 

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/bottomsheet_config.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/bottomsheet_config.dart
@@ -1,3 +1,5 @@
+import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+
 /// Described the Dialog functionality to generate in the app
 class BottomsheetConfig {
   final String import;
@@ -7,4 +9,17 @@ class BottomsheetConfig {
     required this.import,
     required this.bottomsheetClassName,
   });
+
+  /// Returns enum value of BottomSheetType
+  String get enumValue {
+    // The length of class name without Sheet word
+    final wl = bottomsheetClassName.length - 5;
+    final className = bottomsheetClassName.toLowerCamelCase;
+
+    if (className.endsWith('Sheet')) {
+      return className.substring(0, wl);
+    }
+
+    return className;
+  }
 }

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_content.dart
@@ -1,19 +1,22 @@
-import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
-
 String setupBottomsheetHeader(String? locatorName) => '''
-void setupBottomsheetUi() {
-  var bottomsheetService = ${locatorName ?? 'locator'}<BottomSheetService>();
+void setupBottomSheetUi() {
+  final bottomsheetService = ${locatorName ?? 'locator'}<BottomSheetService>();
 
-  final builders = {
+  final Map<BottomSheetType, SheetBuilder> builders = {
   
 ''';
 
-String bottomsheetRegisterContent(String bottomsheetClassName) => '''
-  BottomsheetType.${bottomsheetClassName.toLowerCamelCase}: (context, SheetRequest request, void Function(SheetResponse) completer) =>
+String bottomsheetRegisterContent(
+  String bottomsheetClassName,
+  String enumValue,
+) =>
+    '''
+  BottomSheetType.$enumValue: (context, request, completer) =>
         $bottomsheetClassName(request: request,completer: completer),
 ''';
 
 const bottomsheetRegisterTrailing = '''
+    // @stacked-bottom-sheet-builder
   };
 
   bottomsheetService.setCustomSheetBuilders(builders);

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_content.dart
@@ -16,7 +16,6 @@ String bottomsheetRegisterContent(
 ''';
 
 const bottomsheetRegisterTrailing = '''
-    // @stacked-bottom-sheet-builder
   };
 
   bottomsheetService.setCustomSheetBuilders(builders);

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator.dart
@@ -1,7 +1,7 @@
 import 'package:stacked_generator/src/generators/base_generator.dart';
+import 'package:stacked_generator/src/generators/bottomsheets/bottomsheet_config.dart';
 import 'package:stacked_generator/src/generators/bottomsheets/generate/bottomsheet_class_generator_helper.dart';
 
-import '../bottomsheet_config.dart';
 import 'bottomsheet_class_content.dart';
 
 /// Generates the app.logger.dart file in the users code base.

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator_helper.dart
@@ -9,7 +9,6 @@ class BottomsheetClassGeneratorHelper with StringBufferUtils {
     for (var bottomsheetConfig in bottomsheetConfigs) {
       writeLine('${bottomsheetConfig.enumValue},');
     }
-    writeLine('// @stacked-bottom-sheet-type');
     writeLine("}");
   }
 

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/generate/bottomsheet_class_generator_helper.dart
@@ -1,15 +1,15 @@
 import 'package:stacked_generator/src/generators/base_generator.dart';
-import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+import 'package:stacked_generator/src/generators/bottomsheets/bottomsheet_config.dart';
 
-import '../bottomsheet_config.dart';
 import 'bottomsheet_class_content.dart';
 
 class BottomsheetClassGeneratorHelper with StringBufferUtils {
   void writeBottomsheetTypeEnum(List<BottomsheetConfig> bottomsheetConfigs) {
-    writeLine("enum BottomsheetType{");
+    writeLine("enum BottomSheetType{");
     for (var bottomsheetConfig in bottomsheetConfigs) {
-      writeLine('${bottomsheetConfig.bottomsheetClassName.toLowerCamelCase},');
+      writeLine('${bottomsheetConfig.enumValue},');
     }
+    writeLine('// @stacked-bottom-sheet-type');
     writeLine("}");
   }
 
@@ -20,21 +20,27 @@ class BottomsheetClassGeneratorHelper with StringBufferUtils {
   void writeStackedservicesAndGeneratedLocaterImports() {
     writeLine();
     writeLine("import 'package:stacked_services/stacked_services.dart';");
-    writeLine("import 'app.locator.dart';");
     writeLine();
+    writeLine("import 'app.locator.dart';");
   }
 
   void writeBottomsheetsImports(List<BottomsheetConfig> bottomsheetConfigs) {
     final imports = bottomsheetConfigs.fold<Set<String>>(
-        {}, (previousValue, element) => {...previousValue, element.import});
+      {},
+      (previousValue, element) => {...previousValue, element.import},
+    );
     sortAndGenerate(imports);
     writeLine();
   }
 
   void writeBottomsheetsRegistrationEntries(
-      List<BottomsheetConfig> bottomsheetConfigs) {
+    List<BottomsheetConfig> bottomsheetConfigs,
+  ) {
     for (var bottomsheetConfig in bottomsheetConfigs) {
-      write(bottomsheetRegisterContent(bottomsheetConfig.bottomsheetClassName));
+      write(bottomsheetRegisterContent(
+        bottomsheetConfig.bottomsheetClassName,
+        bottomsheetConfig.enumValue,
+      ));
     }
   }
 }

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/bottomsheet_config_resolver.dart
@@ -3,13 +3,14 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
 import 'package:stacked_generator/src/generators/bottomsheets/bottomsheet_config.dart';
-
-import '../../../../utils.dart';
+import 'package:stacked_generator/utils.dart';
 
 /// Reolves the [BottomsheetConfig] and returns the object if it's supplied
 class BottomsheetConfigResolver {
   List<BottomsheetConfig> resolve(
-      List<DartObject>? bottomsheetsObject, ImportResolver importResolver) {
+    List<DartObject>? bottomsheetsObject,
+    ImportResolver importResolver,
+  ) {
     final bottomSheetConfig = <BottomsheetConfig>[];
 
     // Convert the bottomsheet config into BottomsheetConfig

--- a/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/stacked_bottomsheet_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/bottomsheets/resolve/stacked_bottomsheet_generator.dart
@@ -5,8 +5,8 @@ import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_core/stacked_core.dart';
 import 'package:stacked_generator/import_resolver.dart';
+import 'package:stacked_generator/src/generators/bottomsheets/generate/bottomsheet_class_generator.dart';
 
-import '../generate/bottomsheet_class_generator.dart';
 import 'bottomsheet_config_resolver.dart';
 
 class StackedBottomsheetGenerator extends GeneratorForAnnotation<StackedApp> {

--- a/packages/stacked_generator/lib/src/generators/dialogs/dialog_config.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/dialog_config.dart
@@ -1,3 +1,5 @@
+import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+
 /// Described the Dialog functionality to generate in the app
 class DialogConfig {
   final String import;
@@ -7,4 +9,17 @@ class DialogConfig {
     required this.import,
     required this.dialogClassName,
   });
+
+  /// Returns enum value of DialogType
+  String get enumValue {
+    // The length of class name without DIALOG word
+    final wl = dialogClassName.length - 6;
+    final className = dialogClassName.toLowerCamelCase;
+
+    if (className.endsWith('Dialog')) {
+      return className.substring(0, wl);
+    }
+
+    return className;
+  }
 }

--- a/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_content.dart
@@ -12,7 +12,6 @@ String dialogRegisterContent(String dialogClassName, String enumValue) => '''
 ''';
 
 const dialogRegisterTrailing = '''
-    // @stacked-dialog-builder
   };
 
   dialogService.registerCustomDialogBuilders(builders);

--- a/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_content.dart
@@ -1,19 +1,18 @@
-import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
-
 String setupDialogHeader(String? locatorName) => '''
 void setupDialogUi() {
-  var dialogService = ${locatorName ?? 'locator'}<DialogService>();
+  final dialogService = ${locatorName ?? 'locator'}<DialogService>();
 
-  final builders = {
+  final Map<DialogType, DialogBuilder> builders = {
   
 ''';
 
-String dialogRegisterContent(String dialogClassName) => '''
-  DialogType.${dialogClassName.toLowerCamelCase}: (context, DialogRequest request, void Function(DialogResponse) completer) =>
-        $dialogClassName(request: request,completer: completer),
+String dialogRegisterContent(String dialogClassName, String enumValue) => '''
+  DialogType.$enumValue: (context, request, completer) =>
+        $dialogClassName(request: request, completer: completer),
 ''';
 
 const dialogRegisterTrailing = '''
+    // @stacked-dialog-builder
   };
 
   dialogService.registerCustomDialogBuilders(builders);

--- a/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_generator_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_generator_helper.dart
@@ -9,7 +9,6 @@ class DialogClassGeneratorHelper with StringBufferUtils {
     for (var dialogConfig in dialogConfigs) {
       writeLine('${dialogConfig.enumValue},');
     }
-    writeLine("// @stacked-dialog-type");
     writeLine("}");
   }
 

--- a/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_generator_helper.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/generate/dialog_class_generator_helper.dart
@@ -1,15 +1,15 @@
 import 'package:stacked_generator/src/generators/base_generator.dart';
-import 'package:stacked_generator/src/generators/extensions/string_utils_extension.dart';
+import 'package:stacked_generator/src/generators/dialogs/dialog_config.dart';
 
-import '../dialog_config.dart';
 import 'dialog_class_content.dart';
 
 class DialogClassGeneratorHelper with StringBufferUtils {
   void writeDialogTypeEnum(List<DialogConfig> dialogConfigs) {
     writeLine("enum DialogType{");
     for (var dialogConfig in dialogConfigs) {
-      writeLine('${dialogConfig.dialogClassName.toLowerCamelCase},');
+      writeLine('${dialogConfig.enumValue},');
     }
+    writeLine("// @stacked-dialog-type");
     writeLine("}");
   }
 
@@ -20,20 +20,25 @@ class DialogClassGeneratorHelper with StringBufferUtils {
   void writeStackedservicesAndGeneratedLocaterImports() {
     writeLine();
     writeLine("import 'package:stacked_services/stacked_services.dart';");
-    writeLine("import 'app.locator.dart';");
     writeLine();
+    writeLine("import 'app.locator.dart';");
   }
 
   void writeDialogsImports(List<DialogConfig> dialogConfigs) {
     final imports = dialogConfigs.fold<Set<String>>(
-        {}, (previousValue, element) => {...previousValue, element.import});
+      {},
+      (previousValue, element) => {...previousValue, element.import},
+    );
     sortAndGenerate(imports);
     writeLine();
   }
 
   void writeDialogsRegistrationEntries(List<DialogConfig> dialogConfigs) {
     for (var dialogConfig in dialogConfigs) {
-      write(dialogRegisterContent(dialogConfig.dialogClassName));
+      write(dialogRegisterContent(
+        dialogConfig.dialogClassName,
+        dialogConfig.enumValue,
+      ));
     }
   }
 }

--- a/packages/stacked_generator/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/resolve/dialog_config_resolver.dart
@@ -2,15 +2,16 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_generator/import_resolver.dart';
+import 'package:stacked_generator/src/generators/dialogs/dialog_config.dart';
 import 'package:stacked_generator/src/generators/logging/logger_config.dart';
-
-import '../../../../utils.dart';
-import '../dialog_config.dart';
+import 'package:stacked_generator/utils.dart';
 
 /// Reolves the [LoggerConfig] and returns the object if it's supplied
 class DialogConfigResolver {
   List<DialogConfig> resolve(
-      List<DartObject>? dialogsObject, ImportResolver importResolver) {
+    List<DartObject>? dialogsObject,
+    ImportResolver importResolver,
+  ) {
     final dialogConfigs = <DialogConfig>[];
 
     // Convert the dialog config into DialogConfig
@@ -27,8 +28,10 @@ class DialogConfigResolver {
 
       final className = toDisplayString(dialogClassType);
 
-      dialogConfigs
-          .add(DialogConfig(dialogClassName: className, import: import ?? ''));
+      dialogConfigs.add(DialogConfig(
+        dialogClassName: className,
+        import: import ?? '',
+      ));
     }
 
     return dialogConfigs;

--- a/packages/stacked_generator/lib/src/generators/dialogs/resolve/stacked_dialog_generator.dart
+++ b/packages/stacked_generator/lib/src/generators/dialogs/resolve/stacked_dialog_generator.dart
@@ -5,8 +5,8 @@ import 'package:build/build.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:stacked_core/stacked_core.dart';
 import 'package:stacked_generator/import_resolver.dart';
+import 'package:stacked_generator/src/generators/dialogs/generate/dialog_class_generator.dart';
 
-import '../generate/dialog_class_generator.dart';
 import 'dialog_config_resolver.dart';
 
 class StackedDialogGenerator extends GeneratorForAnnotation<StackedApp> {

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.4
+version: 0.8.5
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
- Changed builder name from dialog to dialogs
- Removed `Sheet` word at end of enum value on BottomSheets
- Removed `Dialog` word at end of enum value on Dialogs
- Added Stacked template identifiers
- Changed Map type for builders, more precise

Merges after #848 because it fixed GitHub Actions.