### PR TITLE
Two Way Text Field Binding

### DIFF
--- a/packages/stacked/example/lib/app/app.bottomsheets.dart
+++ b/packages/stacked/example/lib/app/app.bottomsheets.dart
@@ -5,20 +5,19 @@
 // **************************************************************************
 
 import 'package:stacked_services/stacked_services.dart';
-import 'app.locator.dart';
 
+import 'app.locator.dart';
 import '../ui/bottomsheets/generic_bottomsheet.dart';
 
-enum BottomsheetType {
-  genericBottomSheet,
+enum BottomSheetType {
+  genericBottom,
 }
 
-void setupBottomsheetUi() {
-  var bottomsheetService = exampleLocator<BottomSheetService>();
+void setupBottomSheetUi() {
+  final bottomsheetService = exampleLocator<BottomSheetService>();
 
-  final builders = {
-    BottomsheetType.genericBottomSheet: (context, SheetRequest request,
-            void Function(SheetResponse) completer) =>
+  final Map<BottomSheetType, SheetBuilder> builders = {
+    BottomSheetType.genericBottom: (context, request, completer) =>
         GenericBottomSheet(request: request, completer: completer),
   };
 

--- a/packages/stacked/example/lib/app/app.dialogs.dart
+++ b/packages/stacked/example/lib/app/app.dialogs.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StackedDialogGenerator
+// **************************************************************************
+
+import 'package:stacked_services/stacked_services.dart';
+
+import 'app.locator.dart';
+import '../ui/dialogs/basic_dialog.dart';
+
+enum DialogType {
+  basic,
+}
+
+void setupDialogUi() {
+  final dialogService = exampleLocator<DialogService>();
+
+  final Map<DialogType, DialogBuilder> builders = {
+    DialogType.basic: (context, request, completer) =>
+        BasicDialog(request: request, completer: completer),
+  };
+
+  dialogService.registerCustomDialogBuilders(builders);
+}

--- a/packages/stacked/example/lib/ui/bottom_nav/favorites/favorites_view.dart
+++ b/packages/stacked/example/lib/ui/bottom_nav/favorites/favorites_view.dart
@@ -21,9 +21,9 @@ class FavoritesView extends StatelessWidget {
             style: const TextStyle(fontSize: 30),
           ))),
       viewModelBuilder: () => exampleLocator<FavoritesViewModel>(),
-      onModelReady: (viewModel) => viewModel.setCounterTo999(),
+      onViewModelReady: (viewModel) => viewModel.setCounterTo999(),
       disposeViewModel: false,
-      fireOnModelReadyOnce: true,
+      fireOnViewModelReadyOnce: true,
     );
   }
 }

--- a/packages/stacked/example/lib/ui/form/example_form_view.form.dart
+++ b/packages/stacked/example/lib/ui/form/example_form_view.form.dart
@@ -160,6 +160,47 @@ extension ValueProperties on FormViewModel {
   String? get doYouLoveFoodValue =>
       this.formValueMap[DoYouLoveFoodValueKey] as String?;
 
+  set emailValue(String? value) {
+    this.setData(
+      this.formValueMap
+        ..addAll({
+          EmailValueKey: value,
+        }),
+    );
+
+    if (_ExampleFormViewTextEditingControllers.containsKey(EmailValueKey)) {
+      _ExampleFormViewTextEditingControllers[EmailValueKey]?.text = value ?? '';
+    }
+  }
+
+  set passwordValue(String? value) {
+    this.setData(
+      this.formValueMap
+        ..addAll({
+          PasswordValueKey: value,
+        }),
+    );
+
+    if (_ExampleFormViewTextEditingControllers.containsKey(PasswordValueKey)) {
+      _ExampleFormViewTextEditingControllers[PasswordValueKey]?.text =
+          value ?? '';
+    }
+  }
+
+  set shortBioValue(String? value) {
+    this.setData(
+      this.formValueMap
+        ..addAll({
+          ShortBioValueKey: value,
+        }),
+    );
+
+    if (_ExampleFormViewTextEditingControllers.containsKey(ShortBioValueKey)) {
+      _ExampleFormViewTextEditingControllers[ShortBioValueKey]?.text =
+          value ?? '';
+    }
+  }
+
   bool get hasEmail =>
       this.formValueMap.containsKey(EmailValueKey) &&
       (emailValue?.isNotEmpty ?? false);

--- a/packages/stacked/example/lib/ui/home/home_view.dart
+++ b/packages/stacked/example/lib/ui/home/home_view.dart
@@ -28,7 +28,7 @@ class HomeView extends StatelessWidget {
   Widget build(BuildContext context) {
     return ViewModelBuilder<HomeViewModel>.reactive(
       viewModelBuilder: () => HomeViewModel(),
-      onModelReady: (viewModel) => viewModel.initialise(),
+      onViewModelReady: (viewModel) => viewModel.initialise(),
       builder: (context, viewModel, child) => Scaffold(
         body: Center(
           child: Column(

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+- Adds in the `clearForm` method to be generated
+
 ## 0.9.0
 
 ### New Feature

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+1
+
+- Fixes empty clear form value
+
 ## 0.9.1
 
 - Adds in the `clearForm` method to be generated

--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.9.0
+
+### New Feature
+Two way binding for text fields in Forms. When you want to update the value for a form and have it reflect in the TextField you can now simply set it as using the `fieldValue` property. 
+
+**Example**
+To set the value of a form field called email, you can now in the viewmodel simply do:
+
+```dart
+emailValue = '';
+```
+
+In addition we also have a clearForm function that will clear all the form Text Fields.
+
 ## 0.8.5
 
 - Changes builder name from dialog to dialogs

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -405,6 +405,18 @@ class FormBuilder with StringBufferUtils {
           'String? get ${caseName.camelCase}ValidationMessage => this.fieldsValidationMessages[${_getFormKeyName(caseName)}];');
     }
 
+    // Write out the clearForm method
+    writeLine('void clearForm() {');
+    for (final field in fields) {
+      if (field is! TextFieldConfig) {
+        continue;
+      }
+
+      final caseName = ReCase(field.name);
+      writeLine("${caseName.camelCase}Value = ' '; ");
+    }
+    writeLine('}');
+
     writeLine('}');
     return this;
   }

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -413,7 +413,7 @@ class FormBuilder with StringBufferUtils {
       }
 
       final caseName = ReCase(field.name);
-      writeLine("${caseName.camelCase}Value = ' '; ");
+      writeLine("${caseName.camelCase}Value = ''; ");
     }
     writeLine('}');
 

--- a/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
+++ b/packages/stacked_generator/lib/src/generators/forms/form_builder.dart
@@ -340,6 +340,7 @@ class FormBuilder with StringBufferUtils {
     writeLine('extension ValueProperties on FormViewModel {');
     writeLine("""bool get isFormValid =>
       this.fieldsValidationMessages.values.every((element) => element == null);""");
+
     for (final field in fields) {
       final caseName = ReCase(field.name);
       final type = _getFormFieldValueType(field);
@@ -349,6 +350,34 @@ class FormBuilder with StringBufferUtils {
 
     // Generate the getters that check whether a field is set or not
     newLine();
+
+    // Generate the setters for the values to enable two way binding
+    for (final field in fields) {
+      if (field is! TextFieldConfig) {
+        continue;
+      }
+
+      final type = _getFormFieldValueType(field);
+      final caseName = ReCase(field.name);
+      writeLine('''set ${caseName.camelCase}Value($type? value) { 
+             this.setData(
+              this.formValueMap
+                ..addAll({
+                  ${_getFormKeyName(caseName)}: value,
+                }),
+            );
+
+            if (_${viewName}TextEditingControllers.containsKey(${_getFormKeyName(caseName)})) {
+              _${viewName}TextEditingControllers[${_getFormKeyName(caseName)}]?.text = ${type == 'String' ? "value ?? ''" : '(value ?? DateTime.now()).toIso8601String()'}  ;
+            }
+          }
+
+        ''');
+    }
+
+    // Generate the getters that check whether a field is set or not
+    newLine();
+
     for (final field in fields) {
       final caseName = ReCase(field.name);
       final requiresAdditionalCheck = field is TextFieldConfig;

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.9.0
+version: 0.9.1
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.9.1
+version: 0.9.1+1
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.8.5
+version: 0.9.0
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:


### PR DESCRIPTION
Adds the ability to set the value of the TextEditting controller by calling `[fieldName]Value = 'Text';`

The Values in the viewmodel are now bound to the TextEdittingController values for the form field. 

This makes setting initial values or values from remote sources in the text field much simpler. 

Fixes #382