### PR TITLE
Fix/extend change notifier

### DIFF
--- a/packages/stacked/CHANGELOG.md
+++ b/packages/stacked/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0+4
+- Added fix to extensible classes for ListenableServiceMixin
+
 ## 3.1.0+3
 - Updates promotional banner
 

--- a/packages/stacked/lib/src/mixins/listenable_service_mixin.dart
+++ b/packages/stacked/lib/src/mixins/listenable_service_mixin.dart
@@ -10,16 +10,17 @@ mixin ListenableServiceMixin {
   /// List to the values and react when there are any changes
   void listenToReactiveValues(List<dynamic> reactiveValues) {
     for (var reactiveValue in reactiveValues) {
-      switch (reactiveValue.runtimeType) {
-        case ReactiveValue:
-          reactiveValue.values.listen((value) => notifyListeners());
-          break;
-        case ReactiveList:
-          reactiveValue.onChange.listen((event) => notifyListeners());
-          break;
-        case ChangeNotifier:
-          reactiveValue.addListener(notifyListeners);
-          break;
+      if (reactiveValue is ChangeNotifier) {
+        reactiveValue.addListener(notifyListeners);
+      } else {
+        switch (reactiveValue.runtimeType) {
+          case ReactiveValue:
+            reactiveValue.values.listen((value) => notifyListeners());
+            break;
+          case ReactiveList:
+            reactiveValue.onChange.listen((event) => notifyListeners());
+            break;
+        }
       }
     }
   }

--- a/packages/stacked/lib/src/mixins/listenable_service_mixin.dart
+++ b/packages/stacked/lib/src/mixins/listenable_service_mixin.dart
@@ -9,18 +9,13 @@ mixin ListenableServiceMixin {
 
   /// List to the values and react when there are any changes
   void listenToReactiveValues(List<dynamic> reactiveValues) {
-    for (var reactiveValue in reactiveValues) {
+    for (var reactiveValue in reactiveValues) {      
       if (reactiveValue is ChangeNotifier) {
         reactiveValue.addListener(notifyListeners);
-      } else {
-        switch (reactiveValue.runtimeType) {
-          case ReactiveValue:
-            reactiveValue.values.listen((value) => notifyListeners());
-            break;
-          case ReactiveList:
-            reactiveValue.onChange.listen((event) => notifyListeners());
-            break;
-        }
+      } else if (reactiveValue is ReactiveValue) {
+        reactiveValue.values.listen((value) => notifyListeners());
+      } else if (reactiveValue is ReactiveList) {
+        reactiveValue.onChange.listen((event) => notifyListeners());
       }
     }
   }


### PR DESCRIPTION
When you have a class that exenteds ChangeNotifier, and a child who extends the parent, the function wasn't able to recognize it. With this little change, it will be able to recognize the ChangeNotifier everywhere in the extension tree.