### PR TITLE
[cli] Fix StateError HOME environment variable not set

### DIFF
--- a/packages/stacked_cli/CHANGELOG.md
+++ b/packages/stacked_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.3
+
+- Fixes to avoid StateError when HOME environment variable not set. When this situation happens, XDG_CONFIG_HOME location is not taken into account to find stacked config
+
 ## 1.3.2
 
 - Avoids running pub command if has last version on the system

--- a/packages/stacked_cli/lib/src/services/config_service.dart
+++ b/packages/stacked_cli/lib/src/services/config_service.dart
@@ -119,10 +119,14 @@ class ConfigService {
       return kConfigFileName;
     }
 
-    if (await _fileService.fileExists(
-      filePath: '${_pathService.configHome.path}/stacked/stacked.json',
-    )) {
-      return '${_pathService.configHome.path}/stacked/stacked.json';
+    try {
+      if (await _fileService.fileExists(
+        filePath: '${_pathService.configHome.path}/stacked/stacked.json',
+      )) {
+        return '${_pathService.configHome.path}/stacked/stacked.json';
+      }
+    } on StateError catch (_) {
+      // This error is Thrown when HOME environment variable is not set.
     }
 
     // This is only for backwards compatibility, will be removed on next release

--- a/packages/stacked_cli/lib/src/services/path_service.dart
+++ b/packages/stacked_cli/lib/src/services/path_service.dart
@@ -36,6 +36,7 @@ class PathService {
 
   String basename(String path) => p.basename(path);
 
-  /// The a single base directory relative to which user-specific configuration files should be written. (Corresponds to $XDG_CONFIG_HOME).
+  /// The a single base directory relative to which user-specific configuration
+  /// files should be written. (Corresponds to $XDG_CONFIG_HOME).
   Directory get configHome => xdg.configHome;
 }

--- a/packages/stacked_cli/pubspec.yaml
+++ b/packages/stacked_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_cli
 description: The official dev tools for the Stacked Framework
-version: 1.3.2
+version: 1.3.3
 homepage: https://stacked.filledstacks.com/docs/stacked-cli
 repository: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_cli
 

--- a/packages/stacked_cli/pubspec.yaml
+++ b/packages/stacked_cli/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   recase: ^4.0.0
   json_annotation: ^4.7.0
   ansicolor: ^2.0.1
-  xdg_directories: ^0.2.0+2
+  xdg_directories: ^1.0.0
   usage: ^4.1.0
   pub_updater: ^0.2.4
 

--- a/packages/stacked_cli/test/services/config_service_test.dart
+++ b/packages/stacked_cli/test/services/config_service_test.dart
@@ -129,6 +129,19 @@ void main() {
           fileService.fileExists(filePath: 'stacked.config.json'),
         ]);
       });
+
+      test(
+          'when called without output path, without config file and HOME environment variable is not set'
+          'should NOT call fileExists on fileService for XDG_CONFIG_HOME directory',
+          () async {
+        getAndRegisterPathService(throwStateError: true);
+        final fileService = getAndRegisterFileService(fileExistsResult: false);
+        final service = _getService();
+        await service.resolveConfigFile();
+        verifyNever(fileService.fileExists(
+          filePath: '/Users/filledstacks/.config/stacked/stacked.json',
+        ));
+      });
     });
 
     group('loadConfig -', () {


### PR DESCRIPTION
- Updated xdg_directories
- Fixed to avoid StateError when HOME environment variable not set. When this situation happens, `XDG_CONFIG_HOME` location is not taken into account to find stacked config.
