### PR TITLE
fix(logger): output error in log if non null

### DIFF
--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -40,7 +40,7 @@ class SimpleLogPrinter extends LogPrinter {
         printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
-        '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
+        '\$emoji \$className\$methodNameSection - \${event.message}\${event.error != null ? '\\nERROR: \${event.error}\\n' : ''}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
 
     if (exludeLogsFromClasses
             .any((excludeClass) => className == excludeClass) ||

--- a/packages/stacked_generator/test/logging/simple_log_printer_test.dart
+++ b/packages/stacked_generator/test/logging/simple_log_printer_test.dart
@@ -1,0 +1,110 @@
+import 'dart:isolate';
+
+import 'package:stacked_generator/src/generators/logging/logger_builder.dart';
+import 'package:stacked_generator/src/generators/logging/logger_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SimpleLogPrinterTest -', () {
+    test('returns a correct log message.', () async {
+      final loggerBuilder = LoggerBuilder(loggerConfig: LoggerConfig()).addLoggerClassConstantBody();
+
+      final code = loggerBuilder.serializeStringBuffer;
+
+      final uri = Uri.dataFromString(
+        '''
+        import "dart:isolate";
+        import 'package:logger/logger.dart';
+
+        const kReleaseMode = false;
+        const kIsWeb = false;
+
+        $code
+
+        void main(_, SendPort port) {
+          final logger = SimpleLogPrinter('classname');
+          final result = logger.log(LogEvent(Level.verbose, 'verbose'));
+
+          port.send(result.join('\\n'));
+        }
+        ''',
+        mimeType: 'application/dart',
+      );
+
+      final port = ReceivePort();
+      await Isolate.spawnUri(uri, [], port.sendPort);
+
+      final String response = await port.first;
+
+      expect(response, contains('classname |  - verbose'));
+    });
+
+    test('attaches the stacktrace if requested.', () async {
+      final loggerBuilder = LoggerBuilder(loggerConfig: LoggerConfig()).addLoggerClassConstantBody();
+
+      final code = loggerBuilder.serializeStringBuffer;
+
+      final uri = Uri.dataFromString(
+        '''
+        import "dart:isolate";
+        import 'package:logger/logger.dart';
+
+        const kReleaseMode = false;
+        const kIsWeb = false;
+
+        $code
+
+        void main(_, SendPort port) {
+          final logger = SimpleLogPrinter('classname', printCallStack: true);
+          final result = logger.log(LogEvent(Level.info, 'info'));
+
+          port.send(result.join('\\n'));
+        }
+        ''',
+        mimeType: 'application/dart',
+      );
+
+      final port = ReceivePort();
+      await Isolate.spawnUri(uri, [], port.sendPort);
+
+      final String response = await port.first;
+
+      expect(response, contains('classname |  - info'));
+      expect(response, contains('STACKTRACE:'));
+    });
+
+    test('prints error object if provided.', () async {
+      final loggerBuilder = LoggerBuilder(loggerConfig: LoggerConfig()).addLoggerClassConstantBody();
+
+      final code = loggerBuilder.serializeStringBuffer;
+
+      final uri = Uri.dataFromString(
+        '''
+        import "dart:isolate";
+        import 'package:logger/logger.dart';
+
+        const kReleaseMode = false;
+        const kIsWeb = false;
+
+        $code
+
+        void main(_, SendPort port) {
+          final logger = SimpleLogPrinter('classname');
+          final result = logger.log(LogEvent(Level.error, 'error', Exception('error')));
+
+          port.send(result.join('\\n'));
+        }
+        ''',
+        mimeType: 'application/dart',
+      );
+
+      final port = ReceivePort();
+      await Isolate.spawnUri(uri, [], port.sendPort);
+
+      final String response = await port.first;
+
+      expect(response, contains('classname |  - error'));
+      expect(response, contains('ERROR: Exception: error'));
+    });
+  });
+}


### PR DESCRIPTION
This fixes #877.

Attaches the error object to the log message if it is provided.
Also adds tests for the `SimpleLogPrinter` to ensure the
stacktrace and error objects are logged if provided/requested.
