### PR TITLE
fix(logger): call init/destroy methods for all outputs.

### DIFF
--- a/packages/stacked_generator/CHANGELOG.md
+++ b/packages/stacked_generator/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.4
+
+- Fixes errors not being logged in the stacked logger
+- The multi output (if configured in stacked logger) correctly
+  calls `init` and `destroy` for each output now
+
 ## 0.9.3
 
 - Adds toString to `ViewArguments` that prints out the parameters of the class

--- a/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
+++ b/packages/stacked_generator/lib/src/generators/logging/logger_class_content.dart
@@ -139,22 +139,6 @@ List<String>? _formatStackTrace(StackTrace stackTrace, int methodCount) {
   }
 }
 
-class MultipleLoggerOutput extends LogOutput {
-  final List<LogOutput> logOutputs;
-  MultipleLoggerOutput(this.logOutputs);
-
-  @override
-  void output(OutputEvent event) {
-    for (var logOutput in logOutputs) {
-      try {
-        logOutput.output(event);
-      } catch (e) {
-        print('Log output failed');
-      }
-    }
-  }
-}
-
 ''';
 
 const String loggerClassNameAndOutputs = '''
@@ -173,7 +157,7 @@ Logger $logHelperNameKey(
       showOnlyClass: showOnlyClass,
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
-    output: MultipleLoggerOutput([
+    output: MultiOutput([
       $disableConsoleOutputInRelease
       ConsoleOutput(),
       $multipleLoggerOutput

--- a/packages/stacked_generator/pubspec.yaml
+++ b/packages/stacked_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stacked_generator
 description: Stacked Generator is a package dedicated to reduce the boilerplate required to setup a stacked application
-version: 0.9.3
+version: 0.9.4
 homepage: https://github.com/FilledStacks/stacked/tree/master/packages/stacked_generator
 
 environment:

--- a/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
+++ b/packages/stacked_generator/test/helpers/test_constants/logger_constants.dart
@@ -38,7 +38,7 @@ class SimpleLogPrinter extends LogPrinter {
         printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
-        '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
+        '\$emoji \$className\$methodNameSection - \${event.message}\${event.error != null ? '\\nERROR: \${event.error}\\n' : ''}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
 
     if (exludeLogsFromClasses
             .any((excludeClass) => className == excludeClass) ||
@@ -137,22 +137,6 @@ List<String>? _formatStackTrace(StackTrace stackTrace, int methodCount) {
   }
 }
 
-class MultipleLoggerOutput extends LogOutput {
-  final List<LogOutput> logOutputs;
-  MultipleLoggerOutput(this.logOutputs);
-
-  @override
-  void output(OutputEvent event) {
-    for (var logOutput in logOutputs) {
-      try {
-        logOutput.output(event);
-      } catch (e) {
-        print('Log output failed');
-      }
-    }
-  }
-}
-
 Logger ebraLogger(
   String className, {
   bool printCallingFunctionName = true,
@@ -168,7 +152,7 @@ Logger ebraLogger(
       showOnlyClass: showOnlyClass,
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
-    output: MultipleLoggerOutput([
+    output: MultiOutput([
       if(!kReleaseMode)
       ConsoleOutput(),
        if(kReleaseMode) outputOne(), if(kReleaseMode) outputTwo(),
@@ -216,7 +200,7 @@ class SimpleLogPrinter extends LogPrinter {
         printCallingFunctionName && methodName != null ? ' | \$methodName' : '';
     var stackLog = event.stackTrace.toString();
     var output =
-        '\$emoji \$className\$methodNameSection - \${event.message}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
+        '\$emoji \$className\$methodNameSection - \${event.message}\${event.error != null ? '\\nERROR: \${event.error}\\n' : ''}\${printCallStack ? '\\nSTACKTRACE:\\n\$stackLog' : ''}';
 
     if (exludeLogsFromClasses
             .any((excludeClass) => className == excludeClass) ||
@@ -315,22 +299,6 @@ List<String>? _formatStackTrace(StackTrace stackTrace, int methodCount) {
   }
 }
 
-class MultipleLoggerOutput extends LogOutput {
-  final List<LogOutput> logOutputs;
-  MultipleLoggerOutput(this.logOutputs);
-
-  @override
-  void output(OutputEvent event) {
-    for (var logOutput in logOutputs) {
-      try {
-        logOutput.output(event);
-      } catch (e) {
-        print('Log output failed');
-      }
-    }
-  }
-}
-
 Logger ebraLogger(
   String className, {
   bool printCallingFunctionName = true,
@@ -346,7 +314,7 @@ Logger ebraLogger(
       showOnlyClass: showOnlyClass,
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
-    output: MultipleLoggerOutput([
+    output: MultiOutput([
       
       ConsoleOutput(),
        if(kReleaseMode) outputOne(), if(kReleaseMode) outputTwo(),
@@ -438,7 +406,7 @@ Logger getLogger(
       showOnlyClass: showOnlyClass,
       exludeLogsFromClasses: exludeLogsFromClasses,
     ),
-    output: MultipleLoggerOutput([
+    output: MultiOutput([
       if(!kReleaseMode)
       ConsoleOutput(),
       

--- a/packages/stacked_generator/test/helpers/test_constants/router_constants.dart
+++ b/packages/stacked_generator/test/helpers/test_constants/router_constants.dart
@@ -242,6 +242,11 @@ class TestClassArguments {
   const TestClassArguments({this.markers});
 
   final List<_i3.Marker> markers;
+
+  @override
+  String toString() {
+    return \'{"markers": "\$markers"}\';
+  }
 }
 
 extension NavigatorStateExtension on _i4.NavigationService {
@@ -328,6 +333,11 @@ class TestClassArguments {
   const TestClassArguments({this.name});
 
   final _i3.String name;
+
+  @override
+  String toString() {
+    return \'{"name": "\$name"}\';
+  }
 }
 
 extension NavigatorStateExtension on _i4.NavigationService {
@@ -493,6 +503,11 @@ class TestClass3Arguments {
   const TestClass3Arguments({this.test3paramName});
 
   final _i9.Test3Type test3paramName;
+
+  @override
+  String toString() {
+    return \'{"test3paramName": "\$test3paramName"}\';
+  }
 }
 
 extension NavigatorStateExtension on _i10.NavigationService {
@@ -905,6 +920,11 @@ class LoginClassArguments {
   final _i1.Marker position;
 
   final int age;
+
+  @override
+  String toString() {
+    return '{"position": "\$position", "age": "\$age"}';
+  }
 }
 
 class HomeClassArguments {
@@ -916,5 +936,10 @@ class HomeClassArguments {
   final _i2.Car car;
 
   final int age;
+
+  @override
+  String toString() {
+    return '{"car": "\$car", "age": "\$age"}';
+  }
 }
 ''';

--- a/packages/stacked_generator/test/helpers/test_constants/router_constants.dart
+++ b/packages/stacked_generator/test/helpers/test_constants/router_constants.dart
@@ -245,7 +245,7 @@ class TestClassArguments {
 
   @override
   String toString() {
-    return \'{"markers": "\$markers"}\';
+    return '{"markers": "\$markers"}';
   }
 }
 
@@ -336,7 +336,7 @@ class TestClassArguments {
 
   @override
   String toString() {
-    return \'{"name": "\$name"}\';
+    return '{"name": "\$name"}';
   }
 }
 
@@ -506,7 +506,7 @@ class TestClass3Arguments {
 
   @override
   String toString() {
-    return \'{"test3paramName": "\$test3paramName"}\';
+    return '{"test3paramName": "\$test3paramName"}';
   }
 }
 

--- a/packages/stacked_generator/test/logging/multi_output_test.dart
+++ b/packages/stacked_generator/test/logging/multi_output_test.dart
@@ -1,0 +1,159 @@
+import 'dart:isolate';
+
+import 'package:stacked_generator/src/generators/logging/logger_builder.dart';
+import 'package:stacked_generator/src/generators/logging/logger_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MultiOutputLogger -', () {
+    test('correctly calls init on multi output loggers.', () async {
+      final loggerBuilder = LoggerBuilder(loggerConfig: LoggerConfig(loggerOutputs: ['One', 'Two']))
+          .addLoggerClassConstantBody()
+          .addLoggerNameAndOutputs();
+
+      final code = loggerBuilder.serializeStringBuffer;
+
+      final uri = Uri.dataFromString(
+        '''
+        import "dart:isolate";
+        import 'package:logger/logger.dart';
+
+        const kReleaseMode = true;
+        const kIsWeb = false;
+
+        class One extends LogOutput {
+          static bool initCalled = false;
+          static bool destroyCalled = false;
+
+          @override
+          void init() {
+            initCalled = true;
+            super.init();
+          }
+
+          @override
+          void output(OutputEvent event) {
+          }
+
+          @override
+          void destroy() {
+            destroyCalled = true;
+            super.destroy();
+          }
+        }
+
+        class Two extends LogOutput {
+          static bool initCalled = false;
+          static bool destroyCalled = false;
+
+          @override
+          void init() {
+            initCalled = true;
+            super.init();
+          }
+
+          @override
+          void output(OutputEvent event) {
+          }
+
+          @override
+          void destroy() {
+            destroyCalled = true;
+            super.destroy();
+          }
+        }
+
+        $code
+
+        void main(_, SendPort port) {
+          final logger = getLogger('classname');
+          logger.i('test');
+          port.send([One.initCalled, One.destroyCalled, Two.initCalled, Two.destroyCalled].join('-'));
+        }
+        ''',
+        mimeType: 'application/dart',
+      );
+
+      final port = ReceivePort();
+      await Isolate.spawnUri(uri, [], port.sendPort);
+
+      final String response = await port.first;
+      expect(response, contains('true-false-true-false'));
+    });
+
+    test('correctly calls destroy on multi output loggers.', () async {
+      final loggerBuilder = LoggerBuilder(loggerConfig: LoggerConfig(loggerOutputs: ['One', 'Two']))
+          .addLoggerClassConstantBody()
+          .addLoggerNameAndOutputs();
+
+      final code = loggerBuilder.serializeStringBuffer;
+
+      final uri = Uri.dataFromString(
+        '''
+        import "dart:isolate";
+        import 'package:logger/logger.dart';
+
+        const kReleaseMode = true;
+        const kIsWeb = false;
+
+        class One extends LogOutput {
+          static bool initCalled = false;
+          static bool destroyCalled = false;
+
+          @override
+          void init() {
+            initCalled = true;
+            super.init();
+          }
+
+          @override
+          void output(OutputEvent event) {
+          }
+
+          @override
+          void destroy() {
+            destroyCalled = true;
+            super.destroy();
+          }
+        }
+
+        class Two extends LogOutput {
+          static bool initCalled = false;
+          static bool destroyCalled = false;
+
+          @override
+          void init() {
+            initCalled = true;
+            super.init();
+          }
+
+          @override
+          void output(OutputEvent event) {
+          }
+
+          @override
+          void destroy() {
+            destroyCalled = true;
+            super.destroy();
+          }
+        }
+
+        $code
+
+        void main(_, SendPort port) {
+          final logger = getLogger('classname');
+          logger.close();
+          port.send([One.initCalled, One.destroyCalled, Two.initCalled, Two.destroyCalled].join('-'));
+        }
+        ''',
+        mimeType: 'application/dart',
+      );
+
+      final port = ReceivePort();
+      await Isolate.spawnUri(uri, [], port.sendPort);
+
+      final String response = await port.first;
+      expect(response, contains('true-true-true-true'));
+    });
+  });
+}


### PR DESCRIPTION
This fixes #884.

By utilizing [MultiOutput](https://github.com/Bungeefan/logger/blob/master/lib/src/outputs/multi_output.dart) of the logger package. The output calls init and destroy by default and
normalizes all outputs as well.