### PR TITLE
Add the posibility to add the platform and an organization

### DIFF
--- a/packages/stacked_cli/lib/src/constants/command_constants.dart
+++ b/packages/stacked_cli/lib/src/constants/command_constants.dart
@@ -3,6 +3,8 @@
 const String ksDart = 'dart';
 const String ksFlutter = 'flutter';
 const String ksCreate = 'create';
+const String ksOrganization = "--org";
+const String ksPlatform = "--platform";
 const String ksRun = 'run';
 const String ksPub = 'pub';
 const String ksGet = 'get';

--- a/packages/stacked_cli/lib/src/constants/message_constants.dart
+++ b/packages/stacked_cli/lib/src/constants/message_constants.dart
@@ -56,6 +56,10 @@ const String kCommandHelpCreateBottomSheetTemplate =
 const String kCommandHelpExcludeDependency =
     'When a service is excluded it will not be added to your app.dart dependencies collection.';
 
+const String kCommandOrganizationHelp = "Specifiy the organization bundle-name";
+
+const String kCommandPlatformHelp = "Specifiy the platform to generate for";
+
 const String kConfigFileNotFound =
     'No stacked.json file found. Default stacked values will be used.';
 

--- a/packages/stacked_cli/lib/src/services/process_service.dart
+++ b/packages/stacked_cli/lib/src/services/process_service.dart
@@ -27,10 +27,26 @@ class ProcessService {
   ///
   /// Args:
   ///   appName (String): The name of the app that's going to be create.
-  Future<void> runCreateApp({required String appName}) async {
+  Future<void> runCreateApp(
+      {required String organization,
+      required String platforms,
+      required String appName}) async {
+    List<String> arguments = [];
+    arguments.add(ksCreate);
+
+    if (organization.isNotEmpty) {
+      arguments.addAll([ksOrganization, organization]);
+    }
+
+    if (platforms.isNotEmpty) {
+      arguments.addAll([ksPlatform, platforms]);
+    }
+
+    arguments.add(appName);
     await _runProcess(
       programName: ksFlutter,
-      arguments: [ksCreate, appName],
+      verbose: true,
+      arguments: arguments,
     );
   }
 
@@ -140,6 +156,12 @@ class ProcessService {
         workingDirectory: workingDirectory,
         runInShell: true,
       );
+
+      if (verbose) {
+        process.stderr.listen((event) {
+          _cLog.error(message: "Process error: " + utf8.decoder.convert(event));
+        });
+      }
 
       final lines = <String>[];
       final lineSplitter = LineSplitter();


### PR DESCRIPTION
Hello all,

regarding the following FR which I mentioned the other day (#874) I thought I'd try my hand at it and created something that does what I mentioned.

There are 2 new "arguments" that you can now specify when creating a stacked app.

This would be -o / --org followed by the bundle identifier
```shell
-o com.filledstack 
```
or
```shell
--org com.filledstack
```

and the same for the platform but with -p --platform followed by the platforms separated by ,
 
```shell
-p windows,linux 
```
or
```shell
--platform windows,linux
 ```

Also, I have a kind of check of the app name according to the rules of dart (The name should be written in lowercase, with underscores to separate the words, just_like_this. Use only basic Latin letters and Arabic numerals: [a-z0-9_]. Also make sure that the name is a valid dart identifier, i.e. does not start with digits and is not a reserved word) and that the bundle identfier needs a '.' (com.example)




I have tested it as far as possible, but of course strange or untested things can always happen




Please be merciful with me, it's my first PR :D
For questions or improvement wishes I am gladly open