### PR TITLE
feat: Let ListenableServiceMixin implement Listenable

### DIFF
--- a/lib/src/mixins/listenable_service_mixin.dart
+++ b/lib/src/mixins/listenable_service_mixin.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:stacked/stacked.dart';
 
 /// Adds functionality to easily listen to all reactive values in a service
-mixin ListenableServiceMixin {
+mixin ListenableServiceMixin implements Listenable {
   final List<Function> _listeners = List<Function>.empty(growable: true);
 
   int get listenersCount => _listeners.length;
@@ -21,11 +21,13 @@ mixin ListenableServiceMixin {
   }
 
   /// Registers a listener with this service
+  @override
   void addListener(void Function() listener) {
     _listeners.add(listener);
   }
 
   /// Removes a listener from the service
+  @override
   void removeListener(void Function() listener) {
     _listeners.remove(listener);
   }


### PR DESCRIPTION
Since `ListenableServiceMixin` already implements everything needed for implementing a `Listenable` it makes sense for it to implement that interface. This also opens up some other use cases for it. For example using a `ListenableServiceMixin` in a `ListenableBuilder`.